### PR TITLE
fix: set correct default value when no job_id provided to /upload

### DIFF
--- a/app/routers/chemscraper.py
+++ b/app/routers/chemscraper.py
@@ -17,7 +17,7 @@ from typing import Optional
 router = APIRouter()
 
 @router.post("/{bucket_name}/upload")
-async def upload_file(bucket_name: str, file: UploadFile = File(...), job_id: Optional[str] = Query(None), service: MinIOService = Depends()):
+async def upload_file(bucket_name: str, file: UploadFile = File(...), job_id: Optional[str] = "", service: MinIOService = Depends()):
     first_four_bytes = file.file.read(4)
     file.file.seek(0)
     if first_four_bytes == b'%PDF':


### PR DESCRIPTION
## Problem
When using Swagger UI to test the `/{bucket_name}/upload` endpoint, an HTTP 500 Internal Server Error is raised

<img width="893" alt="Screenshot 2023-07-13 at 10 50 05 AM" src="https://github.com/moleculemaker/mmli-backend/assets/1413653/cfa2460e-7792-408d-923e-3c77d485ccea">

## Approach
* Set `""` instead of `Query(None)` as default when no job_id is provided to `/upload`

## How to Test
1. Checkout and run this branch locally
2. Create (or modify) the `.env` file with the following contents: 
```
# Configure minio defaults
MINIO_ROOT_USER=minioadmin
MINIO_ROOT_PASSWORD=minioadmin

# Configure mmli-backend defaults
MINIO_SERVER="minio:9000"
MINIO_ACCESS_KEY=${MINIO_ROOT_USER}
MINIO_SECRET_KEY=${MINIO_ROOT_PASSWORD}
```
    * NOTE: Docker's DNS will resolve `minio:9000` requests to the minio container running in Docker compose
3. Run `docker compose up -d --build`
    * You should see the Docker images build successfully
    * You should see the Docker containers start successfully: minio + rest + postgresql (currently unused)
4. Navigate to http://localhost:8080/docs in your browser
5. Expand the endpoint for `/{bucket_name}/upload`
    * You should see the parameters listed for the API endpoint
6. Click "Try it Out" at the top right
    * You should see that the parameter inputs are now editable
7. Enter `chemscraper` as the `bucket_name`, but leave the `job_id` blank
8. Scroll down and click "Execute"
    * You should see the upload completes successfully, and returns HTTP 200

<img width="903" alt="Screenshot 2023-07-13 at 11 05 20 AM" src="https://github.com/moleculemaker/mmli-backend/assets/1413653/6dd3a8db-23cb-47ab-9e62-e51b796962bf">