### PR TITLE
Fixed typo in CSV export

### DIFF
--- a/app/routers/files.py
+++ b/app/routers/files.py
@@ -141,14 +141,14 @@ async def analyze_documents(bucket_name: str, requestBody: ExportRequestBody, se
             if requestBody.csv:
                 if requestBody.csv_filter == "full_table":
                     csv_file_data = service.get_file(bucket_name, objectPathPrefix + requestBody.jobId + ".csv")
-                    if cdxml_file_data is None:
+                    if csv_file_data is None:
                         filename = objectPathPrefix + requestBody.jobId + ".csv"
                         raise HTTPException(status_code=404, detail=f"File {filename} not found")
                     new_zip.writestr(requestBody.jobId + ".csv", csv_file_data)
                     files_count += 1
                 elif requestBody.csv_filter == "current_view":
                     csv_file_data = service.get_file(bucket_name, objectPathPrefix + requestBody.jobId + ".csv")
-                    if cdxml_file_data is None:
+                    if csv_file_data is None:
                         filename = objectPathPrefix + requestBody.jobId + ".csv"
                         raise HTTPException(status_code=404, detail=f"File {filename} not found")
                     csvfile = io.StringIO(csv_file_data.decode('utf-8'))


### PR DESCRIPTION
## Problem 
Using [Swagger UI](https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu/docs#/default/analyze_documents__bucket_name__export_results_post), CSV export throws an error: `HTTP 500 - Internal Server Error`

Request Body:
```json
{
  "jobId": "d40952b0-b961-4463-8a58-8d912fd672b5",
  "cdxml": false,
  "cdxml_filter": "all_molecules",
  "cdxml_selected_pages": [],
  "csv": true,
  "csv_filter": "full_table",
  "csv_molecules": [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37]
}
```

The following can be seen in the logs:
```python
  File "/usr/local/lib/python3.10/site-packages/fastapi/routing.py", line 162, in run_endpoint_function
    return await dependant.call(**values)
  File "/code/app/routers/chemscraper.py", line 142, in analyze_documents
    if cdxml_file_data is None:
UnboundLocalError: local variable 'cdxml_file_data' referenced before assignment
```

## Approach
* fix: fixed small typo in the variable names here

## How to Test
TBD