### PR TITLE
fix: fallback to computing atom_count on the fly, if it is not present

### DIFF
--- a/app/routers/files.py
+++ b/app/routers/files.py
@@ -52,6 +52,7 @@ def is_row_flagged(job_id, row, flagged_molecules):
 
 @router.get("/{bucket_name}/results/{job_id}", response_model=List[Molecule], tags=['Files'])
 async def get_results(bucket_name: str, job_id: str, service: MinIOService = Depends(), db: AsyncSession = Depends(get_session)):
+    rdkitService = RDKitService()
     csv_content = service.get_file(bucket_name, "results/" + job_id + "/" + job_id + ".csv")
     if csv_content is None:
         filename = "results/" + job_id + "/" + job_id + ".csv"
@@ -75,7 +76,7 @@ async def get_results(bucket_name: str, job_id: str, service: MinIOService = Dep
         # Create a Molecule object and append it to the list
         molecule = Molecule(id=row['id'],
                             doc_no=row['doc_no'],
-                            atom_count=row['atom_count'] if 'atom_count' in row else RDKitService.getAtomCount(smile),
+                            atom_count=row['atom_count'] if 'atom_count' in row else rdkitService.getAtomCount(smile),
                             file_path=row['file_path'],
                             page_no=row['page_no'],
                             name=row['name'],


### PR DESCRIPTION
## Problem
When fetching job results, Molecules that don't have an `atom_count` cause an error to be thrown

For example: https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu/chemscraper/results/example_PDF

This causes an error stack trace in the backend logs:
```python
INFO:     10.42.152.1:52614 - "GET /chemscraper/results/example_PDF HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 3653, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 147, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 176, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 7080, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 7088, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'atom_count'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/uvicorn/protocols/http/httptools_impl.py", line 435, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/usr/local/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/fastapi/applications.py", line 270, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/starlette/applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/usr/local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.10/site-packages/starlette/middleware/cors.py", line 92, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "/usr/local/lib/python3.10/site-packages/starlette/middleware/cors.py", line 147, in simple_response
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/usr/local/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/usr/local/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 706, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
  File "/usr/local/lib/python3.10/site-packages/fastapi/routing.py", line 236, in app
    raw_response = await run_endpoint_function(
  File "/usr/local/lib/python3.10/site-packages/fastapi/routing.py", line 162, in run_endpoint_function
    return await dependant.call(**values)
  File "/code/app/routers/files.py", line 78, in get_results
    atom_count=row['atom_count'],
  File "/usr/local/lib/python3.10/site-packages/pandas/core/series.py", line 1007, in __getitem__
    return self._get_value(key)
  File "/usr/local/lib/python3.10/site-packages/pandas/core/series.py", line 1116, in _get_value
    loc = self.index.get_loc(label)
  File "/usr/local/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 3655, in get_loc
    raise KeyError(key) from err
KeyError: 'atom_count'
```

## Approach
* fix: fallback to calculating atom_count on the fly, if it was not present in the Molecules that result from the job - this should fix jobs that were run before this feature was present (such as `example_PDF`) :+1:

## How to Test
This is currently deployed to [mmli-backend-staging]

### Old Jobs (missing `atom_count`)
1. Navigate to https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu/results/example_PDF
    * You should see the job results shown (no job execution needed)

### New Jobs (`atom_count` is present)
1. Navigate to https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu/configuration
3. Upload an example PDF and click Analyze
4. Wait for Job to complete
    * You should see the job results shown after the job completes successfully

