### PR TITLE
feat: send email notifications for failed/success in Kubernetes jobs

### DIFF
--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -22,6 +22,14 @@ email:
   fromEmail: "devnull+alphasynthesis@ncsa.illinois.edu"
   fromName: "no-reply-ALPHASYNTHESIS"
 
+# Change frontend service URLs depending on where they're deployed (used for email notifications)
+chemscraper_url: "http://chemscraper-services-staging.staging.svc.cluster.local:8000"
+chemscraper_frontend_url: "https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu"
+novostoic_frontend_url: "https://novostoic.frontend.staging.mmli1.ncsa.illinois.edu"
+somn_frontend_url: "https://somn.frontend.staging.mmli1.ncsa.illinois.edu"
+clean_frontend_url: "https://clean.frontend.staging.mmli1.ncsa.illinois.edu"
+molli_frontend_url: "https://molli.frontend.staging.mmli1.ncsa.illinois.edu"
+
 kubernetes_jobs:
   # Config for running CLEAN job
   clean:

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -53,12 +53,14 @@ config:
       apiBaseUrl: "http://chemscraper-services.alphasynthesis.svc.cluster.local:8000"
       frontendBaseUrl: "https://chemscraper.platform.moleculemaker.org"
 
-  # Change to local chemscraper service URL if deployed in local cluster
-  # TODO: fit this into new config structure
+  # Change to prod service URLs (used for email notifications)
   chemscraper_url: "http://chemscraper-services.alphasynthesis.svc.cluster.local:8000"
   chemscraper_frontend_url: "https://chemscraper.platform.moleculemaker.org"
   novostoic_frontend_url: "https://novostoic.platform.moleculemaker.org"
   somn_frontend_url: "https://somn.platform.moleculemaker.org"
+  clean_frontend_url: "https://clean.platform.moleculemaker.org"
+  molli_frontend_url: "https://molli.platform.moleculemaker.org"
+
 
 postgresql:
   enabled: true

--- a/chart/values.staging.yaml
+++ b/chart/values.staging.yaml
@@ -50,12 +50,13 @@ config:
       apiBaseUrl: "http://chemscraper-services-staging.staging.svc.cluster.local:8000"
       frontendBaseUrl: "https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu"
 
-  # Change to local chemscraper service URL if deployed in local cluster
-  # TODO: fit this into new config structure
+  # Change to staging service URLs (used for email notifications)
   chemscraper_url: "http://chemscraper-services-staging.staging.svc.cluster.local:8000"
   chemscraper_frontend_url: "https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu"
   novostoic_frontend_url: "https://novostoic.frontend.staging.mmli1.ncsa.illinois.edu"
   somn_frontend_url: "https://somn.frontend.staging.mmli1.ncsa.illinois.edu"
+  clean_frontend_url: "https://clean.frontend.staging.mmli1.ncsa.illinois.edu"
+  molli_frontend_url: "https://molli.frontend.staging.mmli1.ncsa.illinois.edu"
 
 postgresql:
   enabled: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -61,6 +61,15 @@ minio:
 
 
 config:
+  # Change frontend service URLs depending on where they're deployed (used for email notifications)
+  # TODO: Default these to local cluster? For now, default is staging and we override for prod
+  chemscraper_url: "http://chemscraper-services-staging.staging.svc.cluster.local:8000"
+  chemscraper_frontend_url: "https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu"
+  novostoic_frontend_url: "https://novostoic.frontend.staging.mmli1.ncsa.illinois.edu"
+  somn_frontend_url: "https://somn.frontend.staging.mmli1.ncsa.illinois.edu"
+  clean_frontend_url: "https://clean.frontend.staging.mmli1.ncsa.illinois.edu"
+  molli_frontend_url: "https://molli.frontend.staging.mmli1.ncsa.illinois.edu"
+
   server:
     port: 8080
     loglevel: "DEBUG"


### PR DESCRIPTION
## Problem
Kubernetes Jobs (e.g. NovoStoic, SOMN, and eventually CLEAN + MOLLI) do not send email notifications on success

ChemScraper jobs currently do this, and it's a very useful feature for users who do not want to wait with the tab open to know whether their job completed

## Approach
* feat: send email notification on successful/failed k8s jobs

## How to Test
TBD