### PR TITLE
feat: upgrade to SOMN 1.5

### DIFF
--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -75,10 +75,9 @@ kubernetes_jobs:
 
   # Config for running SOMN job
   somn:
-    image: "ianrinehart/somn:1.4"
-    #prejob_command: "chown -R 57439:57439 ${JOB_OUTPUT_DIR}/"
-    #command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict last 24-june asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
+    image: "ianrinehart/somn:1.5"
     command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict last latest asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
+    projectDirectory: '/tmp/somn_root/somn_scratch/IID-Models-2024'
     imagePullPolicy: "Always"
     securityContext:
       # TODO: mount/run as mambauser => 57439 causes permission errors

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -75,9 +75,9 @@ kubernetes_jobs:
 
   # Config for running SOMN job
   somn:
-    image: "moleculemaker/somn"
+    image: "ianrinehart/somn:1.4"
     #prejob_command: "chown -R 57439:57439 ${JOB_OUTPUT_DIR}/"
-    command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict 44eb8d94effa11eea46f18c04d0a4970 apr-2024 asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
+    command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict last 24-june asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
     imagePullPolicy: "Always"
     securityContext:
       # TODO: mount/run as mambauser => 57439 causes permission errors

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -76,7 +76,7 @@ kubernetes_jobs:
   # Config for running SOMN job
   somn:
     image: "ianrinehart/somn:1.0"
-    command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict last latest asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
+    command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/test_request.csv && micromamba run -n base somn predict last latest asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
     projectDirectory: '/tmp/somn_root/somn_scratch/IID-Models-2024'
     imagePullPolicy: "Always"
     securityContext:

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -75,7 +75,7 @@ kubernetes_jobs:
 
   # Config for running SOMN job
   somn:
-    image: "ianrinehart/somn:1.5"
+    image: "ianrinehart/somn:1.0"
     command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict last latest asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
     projectDirectory: '/tmp/somn_root/somn_scratch/IID-Models-2024'
     imagePullPolicy: "Always"

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -77,7 +77,8 @@ kubernetes_jobs:
   somn:
     image: "ianrinehart/somn:1.4"
     #prejob_command: "chown -R 57439:57439 ${JOB_OUTPUT_DIR}/"
-    command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict last 24-june asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
+    #command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict last 24-june asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
+    command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict last latest asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
     imagePullPolicy: "Always"
     securityContext:
       # TODO: mount/run as mambauser => 57439 causes permission errors

--- a/app/models/somnRequestBody.py
+++ b/app/models/somnRequestBody.py
@@ -9,3 +9,5 @@ class SomnRequestBody(BaseModel):
     el_name: str
     nuc: str
     nuc_name: str
+    nuc_idx: str
+    el_idx: str

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -102,7 +102,7 @@ async def create_job(
 
             # We assume that file has already been uploaded to MinIO
             #somn_project_dir = '/tmp/somn_root/somn_scratch/last'
-            somn_project_dir = '/tmp/somn_root/somn_scratch/IID-Models-2024'
+            somn_project_dir = app_config['kubernetes_jobs']['somn']['projectDirectory']
             #input_file_path = f'{somn_project_dir}/scratch/example_request.csv'
             #output_file_path = f'{somn_project_dir}/outputs/asdf'
 

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -101,7 +101,7 @@ async def create_job(
                 raise HTTPException(status_code=400, detail="Failed to upload file to MinIO")
 
             # We assume that file has already been uploaded to MinIO
-            somn_project_dir = '/tmp/somn_root/somn_scratch/44eb8d94effa11eea46f18c04d0a4970'
+            somn_project_dir = '/tmp/somn_root/somn_scratch/last'
             #input_file_path = f'{somn_project_dir}/scratch/example_request.csv'
             #output_file_path = f'{somn_project_dir}/outputs/asdf'
 

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -101,7 +101,8 @@ async def create_job(
                 raise HTTPException(status_code=400, detail="Failed to upload file to MinIO")
 
             # We assume that file has already been uploaded to MinIO
-            somn_project_dir = '/tmp/somn_root/somn_scratch/last'
+            #somn_project_dir = '/tmp/somn_root/somn_scratch/last'
+            somn_project_dir = '/tmp/somn_root/somn_scratch/IID-Models-2024'
             #input_file_path = f'{somn_project_dir}/scratch/example_request.csv'
             #output_file_path = f'{somn_project_dir}/outputs/asdf'
 

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -73,11 +73,7 @@ async def create_job(
             command = app_config['kubernetes_jobs'][job_type]['command']
             #command = f'ls -al /uws/jobs/{job_type}/{job_id}'
         elif job_type == JobType.SOMN:
-            project_id = '44eb8d94effa11eea46f18c04d0a4970'
-            model_set = 'apr-2024'
-            new_predictions_name = 'asdf'
-
-            # TODO: Build up example_request.csv from user input, upload to MinIO?
+            #  Build up example_request.csv from user input, upload to MinIO?
             job_config = json.loads(job_info.replace('\"', '"'))
             file = io.StringIO()
             writer = csv.writer(file)
@@ -86,14 +82,18 @@ async def create_job(
                 "nuc", 
                 "el", 
                 "nuc_name", 
-                "el_name"
+                "el_name",
+                "nuc_idx",
+                "el_idx"
             ])
             writer.writerow([
                 "testuser", 
                 job_config["nuc"],
                 job_config["el"], 
                 job_config["nuc_name"], 
-                job_config["el_name"]
+                job_config["el_name"],
+                job_config["nuc_idx"],
+                job_config["el_idx"]
             ])
             
             upload_result = service.upload_file(job_type, f"/{job_id}/in/example_request.csv", file.getvalue().encode('utf-8'))

--- a/chart/modelgen.pod.yaml
+++ b/chart/modelgen.pod.yaml
@@ -16,7 +16,7 @@ spec:
             - "true"
   containers:
     - name: modelgen
-      image: "moleculemaker/novostoic"
+      image: "moleculemaker/novostoic:pr-5"
       command:
         - sleep
         - "3600"

--- a/chart/novostoic.job.yaml
+++ b/chart/novostoic.job.yaml
@@ -1,23 +1,153 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: novostoic-manual-run-optstoic
+  labels:
+    job-name: mmli-job-somn-f4da0fabab0d45f6820062c7183b2cfc
+    jobId: f4da0fabab0d45f6820062c7183b2cfc
+    jobType: somn
+    ownerId: None
+    runId: f4da0fabab0d45f6820062c7183b2cfc
+    type: mmli-job
+  name: mmli-job-somn-f4da0fabab0d45f6820062c7183b2cfc
   namespace: staging
 spec:
+  activeDeadlineSeconds: 259200
+  backoffLimit: 0
+  completionMode: NonIndexed
+  completions: 1
+  parallelism: 1
   template:
+    metadata:
+      labels:
+        job-name: mmli-job-somn-f4da0fabab0d45f6820062c7183b2cfc
+        jobId: f4da0fabab0d45f6820062c7183b2cfc
+        jobType: somn
+        ownerId: None
+        runId: f4da0fabab0d45f6820062c7183b2cfc
+        type: mmli-job
     spec:
-      nodeSelector:
-#        ncsa.role: "worker-gpu"
-        nvidia.com/gpu.present: "true"
       containers:
-      - name: novostoic
-        image: "moleculemaker/novostoic"
-        command: ["python",  "./novostoic-job.py", "optstoic"]
-      tolerations:
-      - effect: NoSchedule
-        key: nvidia.com/gpu
-        operator: Exists
-      imagePullSecrets:
-      - name: regcred
+      - command:
+        - bash
+        - -c
+        - |
+          ./postjob.py
+        env:
+        - name: JOB_ID
+          value: f4da0fabab0d45f6820062c7183b2cfc
+        - name: JOB_TYPE
+          value: somn
+        - name: JOB_OUTPUT_DIR
+          value: /uws/jobs/somn/f4da0fabab0d45f6820062c7183b2cfc/out
+        - name: MINIO_SERVER
+          value: mmli-backend-staging-minio.staging.svc.cluster.local:9000
+        image: moleculemaker/mmli-backend:kubejob
+        imagePullPolicy: Always
+        name: post-job
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /uws
+          name: shared-storage
+          subPath: uws
+        - mountPath: /code/app/cfg/config.yaml
+          name: server-config
+          subPath: config.yaml
+        - mountPath: /code/app/cfg/secret.yaml
+          name: server-secret
+          subPath: secret.yaml
+      dnsPolicy: ClusterFirst
+      initContainers:
+      - command:
+        - /bin/bash
+        - -c
+        - |
+          ./prejob.py
+        env:
+        - name: JOB_ID
+          value: f4da0fabab0d45f6820062c7183b2cfc
+        - name: JOB_TYPE
+          value: somn
+        - name: JOB_OUTPUT_DIR
+          value: /uws/jobs/somn/f4da0fabab0d45f6820062c7183b2cfc/out
+        - name: JOB_INPUT_DIR
+          value: /uws/jobs/somn/f4da0fabab0d45f6820062c7183b2cfc/in
+        - name: MINIO_SERVER
+          value: mmli-backend-staging-minio.staging.svc.cluster.local:9000
+        - name: SOMN_PROJECT_DIR
+          value: /tmp/somn_root/somn_scratch/44eb8d94effa11eea46f18c04d0a4970
+        image: moleculemaker/mmli-backend:kubejob
+        imagePullPolicy: Always
+        name: init
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /uws
+          name: shared-storage
+          subPath: uws
+        - mountPath: /code/app/cfg/config.yaml
+          name: server-config
+          subPath: config.yaml
+        - mountPath: /code/app/cfg/secret.yaml
+          name: server-secret
+          subPath: secret.yaml
+      - command:
+        - bash
+        - -c
+        - |
+          ls -al ${JOB_INPUT_DIR} && cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict 44eb8d94effa11eea46f18c04d0a4970 apr-2024 asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR} && ls -al ${JOB_OUTPUT_DIR} && touch "${JOB_OUTPUT_DIR}/finished"
+        env:
+        - name: JOB_OUTPUT_DIR
+          value: /uws/jobs/somn/f4da0fabab0d45f6820062c7183b2cfc/out
+        - name: JOB_INPUT_DIR
+          value: /uws/jobs/somn/f4da0fabab0d45f6820062c7183b2cfc/in
+        - name: JOB_ID
+          value: f4da0fabab0d45f6820062c7183b2cfc
+        - name: JOB_TYPE
+          value: somn
+        - name: SOMN_PROJECT_DIR
+          value: /tmp/somn_root/somn_scratch/44eb8d94effa11eea46f18c04d0a4970
+        image: moleculemaker/somn
+        imagePullPolicy: Always
+        name: job
+        resources:
+          limits:
+            cpu: "1"
+            memory: 16Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /uws
+          name: shared-storage
+          subPath: uws
+        - mountPath: /uws/jobs/somn/f4da0fabab0d45f6820062c7183b2cfc/in
+          name: shared-storage
+          subPath: uws/jobs/somn/f4da0fabab0d45f6820062c7183b2cfc/in
+        - mountPath: /uws/jobs/somn/f4da0fabab0d45f6820062c7183b2cfc/out
+          name: shared-storage
+          subPath: uws/jobs/somn/f4da0fabab0d45f6820062c7183b2cfc/out
       restartPolicy: Never
-  backoffLimit: 4
+      schedulerName: default-scheduler
+      securityContext:
+      #  fsGroup: 57439
+        runAsGroup: 0
+        runAsUser: 0 
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: mmli-backend-staging-config
+        name: server-config
+      - name: server-secret
+        secret:
+          defaultMode: 420
+          secretName: mmli-backend-staging-secrets
+      - name: shared-storage
+        persistentVolumeClaim:
+          claimName: mmli-clean-job-weights
+  ttlSecondsAfterFinished: 43200

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -32,7 +32,7 @@ config:
         - effect: NoSchedule
           key: nvidia.com/gpu
           operator: Exists
-    novostoic-novastoic:
+    novostoic-pathways:
       # TODO: Temporarily run on GPU node
       nodeSelector:
         nvidia.com/gpu.present: "true"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -146,7 +146,7 @@ config:
     somn:
       image: "ianrinehart/somn:1.0"
       projectDirectory: '/tmp/somn_root/somn_scratch/IID-Models-2024'
-      command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict last latest asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
+      command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/test_request.csv && micromamba run -n base somn predict last latest asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
       imagePullPolicy: "Always"
       securityContext:
         # TODO: mount/run as mambauser => 57439 causes permission errors

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -144,9 +144,9 @@ config:
 
     # Config for running SOMN job
     somn:
-      image: "moleculemaker/somn"
+      image: "ianrinehart/somn:1.4"
       #prejob_command: "chown -R 57439:57439 ${JOB_OUTPUT_DIR}/"
-      command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict 44eb8d94effa11eea46f18c04d0a4970 apr-2024 asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
+      command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict last 24-june asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
       imagePullPolicy: "Always"
       securityContext:
         # TODO: mount/run as mambauser => 57439 causes permission errors

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -145,7 +145,7 @@ config:
     # Config for running SOMN job
     somn:
       image: "ianrinehart/somn:1.5"
-      #prejob_command: "chown -R 57439:57439 ${JOB_OUTPUT_DIR}/"
+      projectDirectory: '/tmp/somn_root/somn_scratch/IID-Models-2024'
       command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict last latest asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
       imagePullPolicy: "Always"
       securityContext:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -144,9 +144,9 @@ config:
 
     # Config for running SOMN job
     somn:
-      image: "ianrinehart/somn:1.4"
+      image: "ianrinehart/somn:1.5"
       #prejob_command: "chown -R 57439:57439 ${JOB_OUTPUT_DIR}/"
-      command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict last 24-june asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
+      command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict last latest asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
       imagePullPolicy: "Always"
       securityContext:
         # TODO: mount/run as mambauser => 57439 causes permission errors

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -144,7 +144,7 @@ config:
 
     # Config for running SOMN job
     somn:
-      image: "ianrinehart/somn:1.5"
+      image: "ianrinehart/somn:1.0"
       projectDirectory: '/tmp/somn_root/somn_scratch/IID-Models-2024'
       command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/example_request.csv && micromamba run -n base somn predict last latest asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
       imagePullPolicy: "Always"


### PR DESCRIPTION
## Problem
Ian has a new image for SOMN version ~~1.5~~ 1.0

We would like to execute this as part of running new SOMN jobs

Includes / supersedes / closes #53 and #52 

## Approach
* feat: upgrade image used to ~~`ianrinehart/somn:1.5`~~ `ianrinehart/somn:1.0`
* fix: update command run to use `somn predict last latest asdf`
* fix: update project paths to use `/tmp/somn_root/somn_scratch/IID-Models-2024`
* fix: overwrite `test_request.csv` in SOMN container (only operate on user's input)

## How to Test
Currently deployed on [staging](https://somn.frontend.staging.mmli1.ncsa.illinois.edu/somn)

1. Navigate to https://somn.frontend.staging.mmli1.ncsa.illinois.edu/somn
2. Click "Use an Example" and submit a new job 
3. Wait for job to complete
    * You should see the results page load after the job has completed