### PR TITLE
fix: log warning if no PubChem results found, skip looping over empty results

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 University of Illinois Board of Trustees
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Problem
The Kassel PDF (attached) produces no results from the PubChem `IDExchange` API call to convert to CIDs

## Approach
* fix: for empty result sets, skip parsing the empty results (since this produces failures)
* fix: adjust order of operations during the parsing phase to avoid encountering errors from the empty results set

## How to Test
Currently deployed on [chemscraper-frontend-staging](https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu/results/2ada25a5e06642e684a275027d146eef)

1. Navigate to [chemscraper-frontend-staging](https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu/configuration)
2. Upload Kassel PDF and click "Analyze with ChemScraper"
3. Wait for processing to complete
4. Verify results - note that some fields (such as molecular weight) will not be populated

Example: https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu/results/2ada25a5e06642e684a275027d146eef