### PR TITLE
feat: integrate molli-frontend + mmli-backend

### DIFF
--- a/app/services/kubejob_service.py
+++ b/app/services/kubejob_service.py
@@ -267,11 +267,15 @@ class KubeEventWatcher:
                         # create session and add objects
                         with Session(self.engine) as session:
                             updated_job = session.get(Job, job_id)
-                            updated_job.phase = new_phase
+                            if updated_job is not None:
+                                updated_job.phase = new_phase
 
-                            session.add(updated_job)
-                            session.commit()
-                            session.flush()
+                                session.add(updated_job)
+                                session.commit()
+                                session.flush()
+                            else:
+                                self.logger.warning('"None" was encountered when fetching Job:', job_id)
+                                self.logger.warning('Skipping database update...')
 
                             self.send_notification_email(updated_job, new_phase)
 

--- a/app/services/kubejob_service.py
+++ b/app/services/kubejob_service.py
@@ -84,9 +84,9 @@ def upload_local_directory_to_minio(local_path: str, bucket_name: str):
         return False
 
     minioClient = Minio(
-        app_config['minio']['server'],
-        access_key=app_config['minio']['accessKey'],
-        secret_key=app_config['minio']['secretKey'],
+        MINIO_SERVER,
+        access_key=MINIO_ACCESS_KEY,
+        secret_key=MINIO_SECRET_KEY,
         secure=False
     )
 

--- a/app/services/molli_service.py
+++ b/app/services/molli_service.py
@@ -1,6 +1,6 @@
 import json
 
-from config import get_logger
+from config import MINIO_SERVER, get_logger
 
 log = get_logger(__name__)
 
@@ -17,6 +17,7 @@ class MolliService:
         # Tell the job to use these files when it runs
         environment.append({'name': 'CORES_INPUT_FILE', 'value': f'{input_dir}/{CORES_FILE_NAME}'})
         environment.append({'name': 'SUBS_INPUT_FILE', 'value': f'{input_dir}/{SUBS_FILE_NAME}'})
+        environment.append({'name': 'MINIO_SERVER', 'value': MINIO_SERVER})
 
         return environment
 
@@ -34,4 +35,4 @@ class MolliService:
             }
         }
 
-        return json.dumps(result)
+        return result


### PR DESCRIPTION
## Problem
`mmli-job-manager` no longer sends notification email upon success or failure of CLEAN/MOLLI jobs

## Approach
* feat: integrate molli-frontend + mmli-backend
    * replaces the legacy `mmli-job-manager` with the new backend `mmli-backend`
* fix: use same MINIO credentials for prejob + postjob

## How to Test
Must be tested with https://github.com/moleculemaker/molli-frontend/pull/59

1. Navigate to https://molli.frontend.staging.mmli1.ncsa.illinois.edu/configuration
2. Download & unzip [MOLLI-input-files.zip](https://github.com/user-attachments/files/16950172/MOLLI-input-files.zip)
3. Upload CORES File: `BOX_cores_test_1.cdxml`
4. Upload SUBS File: `BOX_substituents_test_1.cdxml`
5. Click on "Get the MOLLI result"
6. Wait for job to complete
    * You should see the [results page](https://molli.frontend.staging.mmli1.ncsa.illinois.edu/results/0e29282aaff74bbe8ab1ca6c35c3dede) load and displays visualizations from your current job