### PR TITLE
Add has chiral to SOMN validation workflow

### DIFF
--- a/app/services/somn_service.py
+++ b/app/services/somn_service.py
@@ -60,10 +60,14 @@ class SomnService:
         Raises:
             SomnException: If 3D coordinate generation fails
         """
-        try:            
+        try:
             obmol = pb.readstring("smi", smiles)
-            obmol.addh()
-            
+        except Exception as e:
+            raise SomnException(f"Invalid SMILES string: {smiles}")
+        
+        obmol.addh()
+        
+        try:            
             # this step may fail, so we know SOMN cannot compute on the input
             obmol.make3D() 
             


### PR DESCRIPTION
Closing #62 

## Testing procedure

Go to - https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu/docs#/Somn/check_reaction_sites_somn_all_reaction_sites_get


- Valid chemical
  - with chiral `BrC1=C(C=CC=C1)CO[C@@H]2CCCCO2`, role `el`
     expected output: `..."has_chiral": true...`,
  - without chiral `BrC1=C(C=CC=C1)CO[CH]2CCCCO2`, role `el`
     expected output: `..."has_chiral": false...`,

- Invalid chemical
  - `BrC1=C(C=CC=C1)CO[CH]2CCCCO`, role `el`
     expected output: ` ... "detail": "Invalid SMILES string: BrC1=C(C=CC=C1)CO[C@@H]2CCCCO" ...`

- Chemical which failed 3d testing
   - TBD
   - expected output: ` ... "detail": "Unable to generate 3D coordinates for XXX" ...`