### PR TITLE
64 somnfeature request add endpoints for checking heavy atom number

### DIFF
--- a/app/routers/somn.py
+++ b/app/routers/somn.py
@@ -15,12 +15,13 @@ router = APIRouter()
 class CheckReactionSiteResponse(BaseModel):
     reaction_site_idxes: List[int]
     has_chiral: bool
+    num_heavy_atoms: int
     svg: str
 
 @router.get(f"/{JobType.SOMN}/all-reaction-sites", tags=['Somn'], response_model=CheckReactionSiteResponse)
 async def check_reaction_sites(smiles: str, role: Literal['el', 'nuc']):
     try:
-        reactionSiteIdxes, _, has_chiral = SomnService.check_user_input_substrates(smiles, role)
+        reactionSiteIdxes, _, has_chiral, num_heavy_atoms = SomnService.check_user_input_substrates(smiles, role)
     except SomnException as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
@@ -40,6 +41,7 @@ async def check_reaction_sites(smiles: str, role: Literal['el', 'nuc']):
     return {
         "reaction_site_idxes": reactionSiteIdxes,
         "has_chiral": has_chiral,
+        "num_heavy_atoms": num_heavy_atoms,
         "svg": draw_chemical_svg(smiles, 
                              width=450,
                              height=300,

--- a/app/services/somn_service.py
+++ b/app/services/somn_service.py
@@ -60,10 +60,14 @@ class SomnService:
         Raises:
             SomnException: If 3D coordinate generation fails
         """
-        try:            
+        try:
             obmol = pb.readstring("smi", smiles)
-            obmol.addh()
-            
+        except Exception as e:
+            raise SomnException(f"Invalid SMILES string: {smiles}")
+        
+        obmol.addh()
+        
+        try:            
             # this step may fail, so we know SOMN cannot compute on the input
             obmol.make3D() 
             


### PR DESCRIPTION
Resolves #64, 
Resolves #62

Staging environment is updated with this PR

## Testing procedure #62

Go to - https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu/docs#/Somn/check_reaction_sites_somn_all_reaction_sites_get

Number of heavy atoms = number of non-hydrogen atoms 

- Valid chemical
  - without hydrogen`BrC1=C(C=CC=C1)`, role `el`
     expected output: `..."num_heavy_atoms": 7...`,
  - with hydrogen `BrC1=C(C=CC=C1)CO[C@@H]2CCCCO2`, role `el`
     expected output: `..."num_heavy_atoms": 15...`,

- Invalid chemical
  - `BrC1=C(C=CC=C1)CO[CH]2CCCCO`, role `el`
     expected output: ` ... "detail": "Invalid SMILES string: BrC1=C(C=CC=C1)CO[C@@H]2CCCCO" ...`

- Chemical which failed 3d testing
   - TBD
   - expected output: ` ... "detail": "Unable to generate 3D coordinates for XXX" ...`


## Testing procedure #64
Go to - https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu/docs#/Somn/check_reaction_sites_somn_all_reaction_sites_get

Number of heavy atoms = number of non-hydrogen atoms

Valid chemical

without hydrogenBrC1=C(C=CC=C1), role el
expected output: ..."num_heavy_atoms": 7...,
with hydrogen BrC1=C(C=CC=C1)CO[C@@H]2CCCCO2, role el
expected output: ..."num_heavy_atoms": 15...,
Invalid chemical

BrC1=C(C=CC=C1)CO[CH]2CCCCO, role el
expected output:  ... "detail": "Invalid SMILES string: BrC1=C(C=CC=C1)CO[C@@H]2CCCCO" ...
Chemical which failed 3d testing

TBD
expected output:  ... "detail": "Unable to generate 3D coordinates for XXX" ...