### PR TITLE
63-somnfeature-request---cdxml-file-as-user-input

### DIFF
--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -110,7 +110,7 @@ kubernetes_jobs:
 
   # Config for running SOMN job
   somn:
-    image: "ianrinehart/somn:1.0"
+    image: "ianrinehart/somn:1.1"
     command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/test_request.csv && micromamba run -n base somn predict last latest asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
     projectDirectory: '/tmp/somn_root/somn_scratch/IID-Models-2024'
     imagePullPolicy: "Always"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -175,7 +175,7 @@ config:
 
     # Config for running SOMN job
     somn:
-      image: "ianrinehart/somn:1.0"
+      image: "ianrinehart/somn:1.1"
       projectDirectory: '/tmp/somn_root/somn_scratch/IID-Models-2024'
       command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/test_request.csv && micromamba run -n base somn predict last latest asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
       imagePullPolicy: "Always"

--- a/migrations/versions/bdfd696c3c79_add_is_factor_for_chemical_identifiers.py
+++ b/migrations/versions/bdfd696c3c79_add_is_factor_for_chemical_identifiers.py
@@ -1,7 +1,7 @@
 """add is_factor for chemical_identifiers
 
 Revision ID: bdfd696c3c79
-Revises: 30b240622d34
+Revises: 58fe2962368d
 Create Date: 2024-07-28 15:16:59.193857
 
 """
@@ -12,7 +12,7 @@ import sqlmodel
 
 # revision identifiers, used by Alembic.
 revision = 'bdfd696c3c79'
-down_revision = '30b240622d34'
+down_revision = '58fe2962368d'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Resolves #62
Resolves #63
Resolves #64

Staging environment is updated with this PR

## Testing Procedure #62 

Go to - https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu/docs#/Somn/check_reaction_sites_somn_all_reaction_sites_get


- Valid chemical
  - with chiral `BrC1=C(C=CC=C1)CO[C@@H]2CCCCO2`, role `el`
     expected output: `..."has_chiral": true...`,
  - without chiral `BrC1=C(C=CC=C1)CO[CH]2CCCCO2`, role `el`
     expected output: `..."has_chiral": false...`,

- Invalid chemical
  - `BrC1=C(C=CC=C1)CO[CH]2CCCCO`, role `el`
     expected output: ` ... "detail": "Invalid SMILES string: BrC1=C(C=CC=C1)CO[C@@H]2CCCCO" ...`

- Chemical which failed 3d testing
   - TBD
   - expected output: ` ... "detail": "Unable to generate 3D coordinates for XXX" ...`

## Testing Procedure #63

It is a very rare case and we haven't produced any example for it. However, the feature has been tested with force casting error type to 3d-gen

## Testing procedure #64 

Go to - https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu/docs#/Somn/check_reaction_sites_somn_all_reaction_sites_get

Number of heavy atoms = number of non-hydrogen atoms 

- Valid chemical
  - without hydrogen`BrC1=C(C=CC=C1)`, role `el`
     expected output: `..."num_heavy_atoms": 7...`,
  - with hydrogen `BrC1=C(C=CC=C1)CO[C@@H]2CCCCO2`, role `el`
     expected output: `..."num_heavy_atoms": 15...`,

- Invalid chemical
  - `BrC1=C(C=CC=C1)CO[CH]2CCCCO`, role `el`
     expected output: ` ... "detail": "Invalid SMILES string: BrC1=C(C=CC=C1)CO[C@@H]2CCCCO" ...`

- Chemical which failed 3d testing
   - TBD
   - expected output: ` ... "detail": "Unable to generate 3D coordinates for XXX" ...`