### PR TITLE
add origin for oed

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -54,6 +54,8 @@ origins = [
     "https://novostoic.frontend.mmli1.ncsa.illinois.edu",
     "https://somn.frontend.staging.mmli1.ncsa.illinois.edu",
     "https://somn.frontend.mmli1.ncsa.illinois.edu",
+    "https://frontend.staging.openenzymedb.mmli1.ncsa.illinois.edu",
+    "https://openenzymedb.platform.moleculemaker.org",
     # "http://another.allowed-origin.com", # Add more origins if needed
 ]
 


### PR DESCRIPTION
- this pr fixed OED problem with accessing mmli-backend service
- it has been merged into #68 to make sure somn-staging still works when this pr is active

To test:
- go to https://frontend.staging.openenzymedb.mmli1.ncsa.illinois.edu/query
- click use an example > compound
- you should see SMILES image show up 