### PR TITLE
fix: upgrade Kubernetes client to v31.0.0 to match cluster version

### DIFF
--- a/app/services/kubejob_service.py
+++ b/app/services/kubejob_service.py
@@ -1,5 +1,6 @@
 import glob
 import sys
+import traceback
 
 from kubernetes import watch, client, config as kubeconfig
 from kubernetes.client.rest import ApiException
@@ -298,6 +299,7 @@ class KubeEventWatcher:
                 continue
             except Exception as e:
                 self.logger.error('Unknown exception - KubeWatcher reconnecting to Kube API: %s' % str(e))
+                self.logger.error(traceback.format_exc())
                 if k8s_event_stream:
                     k8s_event_stream.close()
                 k8s_event_stream = None

--- a/app/services/kubejob_service.py
+++ b/app/services/kubejob_service.py
@@ -259,9 +259,9 @@ class KubeEventWatcher:
                     new_phase = None
                     if conditions is None:
                         new_phase = JobStatus.PROCESSING
-                    elif len(conditions) > 0 and conditions[0].type == 'Complete':
+                    elif len(conditions) > 0 and conditions[0].type == 'SuccessCriteriaMet':
                         new_phase = JobStatus.COMPLETED
-                    elif status.failed > 0:
+                    elif status.failed is not None and status.failed > 0:
                         new_phase = JobStatus.ERROR
                     else:
                         self.logger.info(f'>> Skipped job update: {job_id}-> {new_phase}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ python-dotenv==1.0.1
 minio==7.1.17
 rdkit==2023.3.3
 requests==2.31.0
-kubernetes==27.2.0
+kubernetes==31.0.0
 
 # Pin dependencies to specific versions
 # NumPy 2.0.0 is not backwards compatible


### PR DESCRIPTION
## Problem
"COMPLETED" events are being skipped due to an error:
```python
2025-01-29 18:21:02,090 [services.kubejob_service] ERROR    Unknown exception - KubeWatcher reconnecting to Kube API: '>' not supported between instances of 'NoneType' and 'int'
```

## Approach
* fix: upgrade k8s client to v31.0.0 to match our Kubernetes version on the cluster: `1.31`
* fix: print stacktrace in the logs for Unknown exceptions in KubeWatcher
* fix: adjust failure/completed case checks to avoid the NoneType comparison error above

## How to Test
Deployed to `mmli-backend-staging`

1. Navigate to https://clean.frontend.staging.mmli1.ncsa.illinois.edu
2. Submit a new job:
```
>1234
asdf
```
3. When job completes, you should see results
    * Example: https://clean.frontend.staging.mmli1.ncsa.illinois.edu/results/209ec5fc71324e5d984dd65f8ddaa01d/1