### PR TITLE
fix: use correct path for CSV export filename

### DIFF
--- a/app/routers/files.py
+++ b/app/routers/files.py
@@ -1,6 +1,6 @@
 import csv
 import io
-
+import sys
 import uuid
 import zipfile
 from datetime import datetime
@@ -31,6 +31,8 @@ from typing import Optional
 router = APIRouter()
 
 log = get_logger(__name__)
+
+csv.field_size_limit(sys.maxsize)
 
 @router.post("/{bucket_name}/upload", tags=['Files'])
 async def upload_file(bucket_name: str, file: UploadFile = File(...), job_id: Optional[str] = "", minio: MinIOService = Depends()):
@@ -142,16 +144,16 @@ async def analyze_documents(bucket_name: str, requestBody: ExportRequestBody, se
                     files_count += 1
             if requestBody.csv:
                 if requestBody.csv_filter == "full_table":
-                    csv_file_data = service.get_file(bucket_name, objectPathPrefix + requestBody.jobId + ".csv")
+                    csv_file_data = service.get_file(bucket_name, objectPathPrefix + requestBody.jobId + "-results.csv")
                     if csv_file_data is None:
                         filename = objectPathPrefix + requestBody.jobId + "-results.csv"
                         raise HTTPException(status_code=404, detail=f"File {filename} not found")
-                    new_zip.writestr(requestBody.jobId + ".csv", csv_file_data)
+                    new_zip.writestr(requestBody.jobId + "-results.csv", csv_file_data)
                     files_count += 1
                 elif requestBody.csv_filter == "current_view":
                     csv_file_data = service.get_file(bucket_name, objectPathPrefix + requestBody.jobId + "-results.csv")
                     if csv_file_data is None:
-                        filename = objectPathPrefix + requestBody.jobId + ".csv"
+                        filename = objectPathPrefix + requestBody.jobId + "-results.csv"
                         raise HTTPException(status_code=404, detail=f"File {filename} not found")
                     csvfile = io.StringIO(csv_file_data.decode('utf-8'))
                     reader = csv.DictReader(csvfile)
@@ -161,7 +163,7 @@ async def analyze_documents(bucket_name: str, requestBody: ExportRequestBody, se
                     writer = csv.DictWriter(output_csv, fieldnames=reordered_rows[0].keys())
                     writer.writeheader()
                     writer.writerows(reordered_rows)
-                    new_zip.writestr(requestBody.jobId + ".csv", output_csv.getvalue())
+                    new_zip.writestr(requestBody.jobId + "-results.csv", output_csv.getvalue())
                     files_count += 1
 
         if files_count > 0:

--- a/app/routers/files.py
+++ b/app/routers/files.py
@@ -144,12 +144,12 @@ async def analyze_documents(bucket_name: str, requestBody: ExportRequestBody, se
                 if requestBody.csv_filter == "full_table":
                     csv_file_data = service.get_file(bucket_name, objectPathPrefix + requestBody.jobId + ".csv")
                     if csv_file_data is None:
-                        filename = objectPathPrefix + requestBody.jobId + ".csv"
+                        filename = objectPathPrefix + requestBody.jobId + "-results.csv"
                         raise HTTPException(status_code=404, detail=f"File {filename} not found")
                     new_zip.writestr(requestBody.jobId + ".csv", csv_file_data)
                     files_count += 1
                 elif requestBody.csv_filter == "current_view":
-                    csv_file_data = service.get_file(bucket_name, objectPathPrefix + requestBody.jobId + ".csv")
+                    csv_file_data = service.get_file(bucket_name, objectPathPrefix + requestBody.jobId + "-results.csv")
                     if csv_file_data is None:
                         filename = objectPathPrefix + requestBody.jobId + ".csv"
                         raise HTTPException(status_code=404, detail=f"File {filename} not found")


### PR DESCRIPTION
## Problem
ChemScraper "Export as CSV" is throwing an error:
```
Arguments: (S3Error('S3 operation failed; code: NoSuchKey, message: The specified key does not exist., resource: /chemscraper/9a5b9b88bf6349bf94911b1b73dbc7fd/out/9a5b9b88bf6349bf94911b1b73dbc7fd.csv, request_id: 18260A0538B046B0, host_id: dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8, bucket_name: chemscraper, object_name: 9a5b9b88bf6349bf94911b1b73dbc7fd/out/9a5b9b88bf6349bf94911b1b73dbc7fd.csv'),)
```

It looks like a file _does_ exist in this bucket at the path `9a5b9b88bf6349bf94911b1b73dbc7fd/out/9a5b9b88bf6349bf94911b1b73dbc7fd-results.csv`

## Approach
* fix: use the correct CSV filename for exporting these results

## How to Test
This is currently deployed to [mmli-backend-staging](https://argocd.devops.ncsa.illinois.edu/applications/argocd/mmli-backend-staging?resource=)

1. Navigate to the results page for a finished job
    * For example, see [Hadrien's reported job](https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu/results/9a5b9b88bf6349bf94911b1b73dbc7fd)
2. At the top-right, click Export
    * You should see a dialog appear allowing you to choose parameters of your export
3. Choose CSV (either full table or current view) and confirm the dialog
    * You should see a CSV file is downloaded as expected
    * You should no longer see the error from the top of this ticket
4. Repeat the step 3 with the other CSV option (either current view or full table)
    * You should see a CSV file is downloaded as expected
    * You should no longer see the error from the top of this ticket