### PR TITLE
[WIP] Use newest SOMN image 1.2

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -221,7 +221,7 @@ config:
 
     # Config for running SOMN job
     somn:
-      image: "ianrinehart/somn:1.1"
+      image: "ianrinehart/somn:1.2"
       projectDirectory: '/tmp/somn_root/somn_scratch/IID-Models-2024'
       command: "cp ${JOB_INPUT_DIR}/example_request.csv ${SOMN_PROJECT_DIR}/scratch/test_request.csv && micromamba run -n base somn predict last latest asdf && cp -r ${SOMN_PROJECT_DIR}/outputs/asdf/*/* ${JOB_OUTPUT_DIR}"
       imagePullPolicy: "Always"


### PR DESCRIPTION
## Problem
We currently have a manual change in `staging` to upgrade to the SOMN 1.2 image

## Approach
* fix: commit this change to git, so that it won't be overwritten by the next sync

## How to Test
TBD