### PR TITLE
fix: treat mapping.csv contents as a string when gathering result JSON

### DIFF
--- a/app/services/reactionminer_service.py
+++ b/app/services/reactionminer_service.py
@@ -36,6 +36,7 @@ class ReactionMinerService:
         content = {}
         for obj in objects:
             file_name = os.path.basename(obj.object_name).split('/')[-1]
+            log.debug(f'Found: {file_name}')
             if file_name.endswith('.json'):
                 content[file_name] = json.loads(service.get_file(bucket_name=bucket_name, object_name=obj.object_name))
             elif file_name.endswith('.csv'):

--- a/app/services/reactionminer_service.py
+++ b/app/services/reactionminer_service.py
@@ -36,7 +36,6 @@ class ReactionMinerService:
         content = {}
         for obj in objects:
             file_name = os.path.basename(obj.object_name).split('/')[-1]
-            log.debug(f'Found: {file_name}')
             if file_name.endswith('.json'):
                 content[file_name] = json.loads(service.get_file(bucket_name=bucket_name, object_name=obj.object_name))
             elif file_name.endswith('.csv'):

--- a/app/services/reactionminer_service.py
+++ b/app/services/reactionminer_service.py
@@ -36,7 +36,12 @@ class ReactionMinerService:
         content = {}
         for obj in objects:
             file_name = os.path.basename(obj.object_name).split('/')[-1]
-            content[file_name] = json.loads(service.get_file(bucket_name=bucket_name, object_name=obj.object_name))
+            if file_name.endswith('.json'):
+                content[file_name] = json.loads(service.get_file(bucket_name=bucket_name, object_name=obj.object_name))
+            elif file_name.endswith('.csv'):
+                content[file_name] = service.get_file(bucket_name=bucket_name, object_name=obj.object_name)
+            else:
+                log.warning(f'Skipping unrecognized file extension: ' + str(file_name))
 
         # Return the dictionary if it has contents
         if not content:


### PR DESCRIPTION
## Problem
Our current results API endpoint for ReactionMiner assumes that all result files will be JSON

This does not account for `mapping.csv` which is saved for debug purposes

## Approach
* fix: Handle JSON and CSV file types separately when parsing results into a dictionary

Alternatively we could convert this mapping to JSON

## How to Test
Currently deployed to `staging`

1. Navigate to https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu/docs#/Files/get_results__bucket_name__results__job_id__get
2. Click "Try It Out!"
3. Enter `bucket_name=reactionminer` and `job_id=demo`, and click Execute
    * You should see that a mapping of all result files is returned
    * You should see mapping.csv is printed as a raw string to avoid JSON decoding issues - we can change this format if something else might be more convenient