### PR TITLE
feat: run all but enzrank + reactionminer + aceretro on cpu node and tune resources

### DIFF
--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -108,6 +108,8 @@ config:
           value: '/root/.cache/token'
         - name: GROBID_SERVER
           value: 'mmli-grobid.alphasynthesis.svc.cluster.local'
+        - name: CHEMSCRAPER_BASE_URL	
+          value: "http://chemscraper-services.alphasynthesis.svc.cluster.local:8000"	
       # Run ReactionMiner on GPU node
       nodeSelector:
         nvidia.com/gpu.present: "true"

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -25,15 +25,21 @@ config:
     apiBaseUrl: "minioapi.mmli.fastapi.mmli1.ncsa.illinois.edu"
   kubernetes_jobs:
     novostoic-dgpredictor:
-      # TODO: Temporarily run on GPU node
-      nodeSelector:
-        nvidia.com/gpu.present: "true"
-      tolerations:
-        - effect: NoSchedule
-          key: nvidia.com/gpu
-          operator: Exists
-    novostoic-pathways:
-      # TODO: Temporarily run on GPU node
+      resources:
+        limits:
+          cpu: "1"
+          memory: 16Gi
+        requests:
+          cpu: "1"
+          memory: 12Gi
+    novostoic-enxrank:
+      resources:
+        limits:
+          cpu: "1"
+          memory: 12Gi
+        requests:
+          cpu: "1"
+          memory: 8Gi
       nodeSelector:
         nvidia.com/gpu.present: "true"
       tolerations:
@@ -41,13 +47,21 @@ config:
           key: nvidia.com/gpu
           operator: Exists
     novostoic-optstoic:
-      # TODO: Temporarily run on GPU node
-      nodeSelector:
-        nvidia.com/gpu.present: "true"
-      tolerations:
-        - effect: NoSchedule
-          key: nvidia.com/gpu
-          operator: Exists
+      resources:
+        limits:
+          cpu: "1"
+          memory: 12Gi
+        requests:
+          cpu: "1"
+          memory: 8Gi
+    novostoic-pathways:
+      resources:
+        limits:
+          cpu: "1"
+          memory: 12Gi
+        requests:
+          cpu: "1"
+          memory: 8Gi
     reactionminer:
       # Override Grobid server host for production
       env:

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -25,6 +25,12 @@ config:
     apiBaseUrl: "minioapi.mmli.fastapi.mmli1.ncsa.illinois.edu"
   kubernetes_jobs:
     novostoic-dgpredictor:
+      nodeSelector:  
+        ncsa.role: worker-job  
+      tolerations:  
+      - effect: NoSchedule  
+        key: mmli.role  
+        operator: Exists
       resources:
         limits:
           cpu: "1"
@@ -32,7 +38,7 @@ config:
         requests:
           cpu: "1"
           memory: 12Gi
-    novostoic-enxrank:
+    novostoic-enzrank:
       resources:
         limits:
           cpu: "1"
@@ -47,6 +53,12 @@ config:
           key: nvidia.com/gpu
           operator: Exists
     novostoic-optstoic:
+      nodeSelector:  
+        ncsa.role: worker-job  
+      tolerations:  
+      - effect: NoSchedule  
+        key: mmli.role  
+        operator: Exists
       resources:
         limits:
           cpu: "1"
@@ -55,6 +67,12 @@ config:
           cpu: "1"
           memory: 8Gi
     novostoic-pathways:
+      nodeSelector:  
+        ncsa.role: worker-job  
+      tolerations:  
+      - effect: NoSchedule  
+        key: mmli.role  
+        operator: Exists
       resources:
         limits:
           cpu: "1"
@@ -62,6 +80,27 @@ config:
         requests:
           cpu: "1"
           memory: 8Gi
+    clean:
+      nodeSelector:  
+        ncsa.role: worker-job  
+      tolerations:  
+      - effect: NoSchedule  
+        key: mmli.role  
+        operator: Exists
+    molli:
+      nodeSelector:  
+        ncsa.role: worker-job  
+      tolerations:  
+      - effect: NoSchedule  
+        key: mmli.role  
+        operator: Exists
+    aceretro:
+      nodeSelector:  
+        ncsa.role: worker-job  
+      tolerations:  
+      - effect: NoSchedule  
+        key: mmli.role  
+        operator: Exists
     reactionminer:
       # Override Grobid server host for production
       env:

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -95,12 +95,12 @@ config:
         key: mmli.role  
         operator: Exists
     aceretro:
-      nodeSelector:  
-        ncsa.role: worker-job  
-      tolerations:  
-      - effect: NoSchedule  
-        key: mmli.role  
-        operator: Exists
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
     reactionminer:
       # Override Grobid server host for production
       env:

--- a/chart/values.staging.yaml
+++ b/chart/values.staging.yaml
@@ -19,14 +19,13 @@ analyzeIngress:
 config:
   kubernetes_jobs:
     novostoic-dgpredictor:
-      resources:
-        limits:
-          cpu: "1"
-          memory: 16Gi
-        requests:
-          cpu: "1"
-          memory: 12Gi
-    novostoic-enxrank:
+      nodeSelector:	
+        ncsa.role: worker-job	
+      tolerations:	
+      - effect: NoSchedule	
+        key: mmli.role	
+        operator: Exists
+    novostoic-enzrank:
       resources:
         limits:
           cpu: "1"
@@ -48,6 +47,12 @@ config:
         requests:
           cpu: "1"
           memory: 8Gi
+      nodeSelector:	
+        ncsa.role: worker-job	
+      tolerations:	
+      - effect: NoSchedule	
+        key: mmli.role	
+        operator: Exists
     novostoic-pathways:
       resources:
         limits:
@@ -56,7 +61,41 @@ config:
         requests:
           cpu: "1"
           memory: 8Gi
+      nodeSelector:  
+        ncsa.role: worker-job  
+      tolerations:  
+      - effect: NoSchedule  
+        key: mmli.role  
+        operator: Exists
+    clean:
+      nodeSelector:  
+        ncsa.role: worker-job  
+      tolerations:  
+      - effect: NoSchedule  
+        key: mmli.role  
+        operator: Exists
+    molli:
+      nodeSelector:  
+        ncsa.role: worker-job  
+      tolerations:  
+      - effect: NoSchedule  
+        key: mmli.role  
+        operator: Exists
+    aceretro:
+      nodeSelector:  
+        ncsa.role: worker-job  
+      tolerations:  
+      - effect: NoSchedule  
+        key: mmli.role  
+        operator: Exists
     reactionminer:
+      resources:	
+        limits:	
+          cpu: "1"	
+          memory: 24Gi	
+        requests:	
+          cpu: "1"	
+          memory: 20Gi
       nodeSelector:
         nvidia.com/gpu.present: "true"
       tolerations:

--- a/chart/values.staging.yaml
+++ b/chart/values.staging.yaml
@@ -82,12 +82,12 @@ config:
         key: mmli.role  
         operator: Exists
     aceretro:
-      nodeSelector:  
-        ncsa.role: worker-job  
-      tolerations:  
-      - effect: NoSchedule  
-        key: mmli.role  
-        operator: Exists
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
     reactionminer:
       resources:	
         limits:	

--- a/chart/values.staging.yaml
+++ b/chart/values.staging.yaml
@@ -19,15 +19,21 @@ analyzeIngress:
 config:
   kubernetes_jobs:
     novostoic-dgpredictor:
-      # TODO: Temporarily run on GPU node
-      nodeSelector:
-        nvidia.com/gpu.present: "true"
-      tolerations:
-        - effect: NoSchedule
-          key: nvidia.com/gpu
-          operator: Exists
-    novostoic-pathways:
-      # TODO: Temporarily run on GPU node
+      resources:
+        limits:
+          cpu: "1"
+          memory: 16Gi
+        requests:
+          cpu: "1"
+          memory: 12Gi
+    novostoic-enxrank:
+      resources:
+        limits:
+          cpu: "1"
+          memory: 12Gi
+        requests:
+          cpu: "1"
+          memory: 8Gi
       nodeSelector:
         nvidia.com/gpu.present: "true"
       tolerations:
@@ -35,14 +41,21 @@ config:
           key: nvidia.com/gpu
           operator: Exists
     novostoic-optstoic:
-      # TODO: Temporarily run on GPU node
-      nodeSelector:
-        nvidia.com/gpu.present: "true"
-      tolerations:
-        - effect: NoSchedule
-          key: nvidia.com/gpu
-          operator: Exists
-    # Run on GPU node
+      resources:
+        limits:
+          cpu: "1"
+          memory: 12Gi
+        requests:
+          cpu: "1"
+          memory: 8Gi
+    novostoic-pathways:
+      resources:
+        limits:
+          cpu: "1"
+          memory: 12Gi
+        requests:
+          cpu: "1"
+          memory: 8Gi
     reactionminer:
       nodeSelector:
         nvidia.com/gpu.present: "true"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -175,7 +175,7 @@ config:
 
     # Config for running ReactionMiner job
     reactionminer:
-      image: "moleculemaker/reactionminer:latest"
+      image: "moleculemaker/reactionminer:ReactionMiner_v2"
       imagePullPolicy: "Always"
       env:
       - name: HF_TOKEN_PATH

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -182,6 +182,8 @@ config:
         value: '/root/.cache/token'
       - name: GROBID_SERVER
         value: 'mmli-grobid-staging.staging.svc.cluster.local'
+      - name: CHEMSCRAPER_BASE_URL	
+        value: "http://chemscraper-services-staging.staging.svc.cluster.local:8000"	
       volumes:
         - name: 'shared-storage'
           mountPath: '/workspace/10test/'

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -244,10 +244,8 @@ config:
     # Config for running NovoStoic job (subjob: OptStoic)
     novostoic-optstoic:
       image: "moleculemaker/novostoic"
-      command: "python ./novostoic-job.py optstoic"
+      command: python ./novostoic-job.py optstoic 1> ${JOB_OUTPUT_DIR}/output.log 2> ${JOB_OUTPUT_DIR}/error.log; if [ "$?" -eq 0 ]; then touch ${JOB_OUTPUT_DIR}/success; else touch ${JOB_OUTPUT_DIR}/fail; fi
       imagePullPolicy: "Always"
-      #imagePullSecrets:
-      #  - regcred
       volumes:
         - name: 'shared-storage'
           mountPath: '/uws/jobs/novostoic-optstoic/JOB_ID/out'
@@ -264,10 +262,8 @@ config:
     # Config for running NovoStoic job (subjob: NovoStoic Pathways Search)
     novostoic-pathways:
       image: "moleculemaker/novostoic"
-      command: "python ./novostoic-job.py pathways"
+      command: python ./novostoic-job.py pathways 1> ${JOB_OUTPUT_DIR}/output.log 2> ${JOB_OUTPUT_DIR}/error.log; if [ "$?" -eq 0 ]; then touch ${JOB_OUTPUT_DIR}/success; else touch ${JOB_OUTPUT_DIR}/fail; fi
       imagePullPolicy: "Always"
-      #imagePullSecrets:
-      #  - regcred
       volumes:
         - name: 'shared-storage'
           mountPath: 'uws/jobs/novostoic-pathways/JOB_ID/out'
@@ -277,10 +273,8 @@ config:
     # Config for running NovoStoic job (subjob: dGPredictor)
     novostoic-dgpredictor:
       image: "moleculemaker/novostoic"
-      command: "python ./novostoic-job.py dgpredictor"
+      command: python ./novostoic-job.py dgpredictor 1> ${JOB_OUTPUT_DIR}/output.log 2> ${JOB_OUTPUT_DIR}/error.log; if [ "$?" -eq 0 ]; then touch ${JOB_OUTPUT_DIR}/success; else touch ${JOB_OUTPUT_DIR}/fail; fi
       imagePullPolicy: "Always"
-      #imagePullSecrets:
-      #  - regcred
       volumes:
         - name: 'shared-storage'
           mountPath: '/uws/jobs/novostoic-dgpredictor/JOB_ID/out'
@@ -290,10 +284,8 @@ config:
     # Config for running NovoStoic job (subjob: EnzRank)
     novostoic-enzrank:
       image: "moleculemaker/novostoic"
-      command: "python ./novostoic-job.py enzrank"
+      command: python ./novostoic-job.py enzrank 1> ${JOB_OUTPUT_DIR}/output.log 2> ${JOB_OUTPUT_DIR}/error.log; if [ "$?" -eq 0 ]; then touch ${JOB_OUTPUT_DIR}/success; else touch ${JOB_OUTPUT_DIR}/fail; fi
       imagePullPolicy: "Always"
-      #imagePullSecrets:
-      #  - regcred
       volumes:
         - name: 'shared-storage'
           mountPath: '/uws/jobs/novostoic-enzrank/JOB_ID/out'


### PR DESCRIPTION
## Problem
The GPU is suffocating under the weight of jobs that don't need to run there.

We would like to adjust which jobs run on which nodes so that only those that need the GPU node will run there.

Now that we have expanded our cluster capacity, we have created two new nodes `mmli1-worker-job-01` and `mmli1-worker-job-02` where we would like to run all jobs that do not require a GPU

Fixes #79 

## Approach
* feat: properly terminate novostoic jobs to account for and track errors (thanks @ckouder!)
* feat: run all jobs (except EnzRank + ReactionMiner + ACERetro) on new `mmli1-worker-job-##` nodes
* fix: explicitly set CHEMSCRAPER_BASE_URL in staging/prod ReactionMiner job
* fix: pin ReactionMiner job container to `ReactionMiner_v2` tag from [ReactionMiner autobuild](https://github.com/moleculemaker/ReactionMiner/actions/runs/14071356168/job/39406045635)

## How to Test
Currently deployed in `staging` and `prod`

1. Run a job of each type in `staging`:
    * `chemscraper` -> https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu/configuration
    * `aceretro` -> https://aceretro.frontend.staging.mmli1.ncsa.illinois.edu/search-routes
    * `reactionminer` -> https://reactionminer.frontend.staging.mmli1.ncsa.illinois.edu/reaction-miner
    * `novostoic-enzrank` -> https://novostoic.frontend.staging.mmli1.ncsa.illinois.edu/enzyme-selection
    * `novostoic-optstoic` -> https://novostoic.frontend.staging.mmli1.ncsa.illinois.edu/overall-stoichiometry
    * `novostoic-pathways` -> https://novostoic.frontend.staging.mmli1.ncsa.illinois.edu/pathway-search
    * `novostoic-dgpredictor` -> https://novostoic.frontend.staging.mmli1.ncsa.illinois.edu/thermodynamical-feasibility
    * `clean` -> https://clean.frontend.staging.mmli1.ncsa.illinois.edu/configuration
    * `somn` -> https://somn.frontend.staging.mmli1.ncsa.illinois.edu/home
    * `molli` -> https://molli.frontend.staging.mmli1.ncsa.illinois.edu/configuration
2. Run `kubectl get pods -n staging -o wide | grep mmli-job`
    * You should see that a pod was created for each job matching the ID that is submitted from the UI (note that novostoic ID is cut off in the pod name)
    * You should see each job run on the predetermined NODE:
        * `chemscraper` -> no job is run (future: we could easily create a job for this too)
        * `aceretro` -> ~`mmli1-worker-job-0X1`~ `mmli1-worker-gpu-01` (~CPU~ GPU)
        * `reactionminer` -> `mmli1-worker-gpu-01` (GPU)
        * `novostoic-enzrank` -> `mmli1-worker-gpu-01` (GPU)
        * `novostoic-optstoic` -> `mmli1-worker-job-0X` (CPU)
        * `novostoic-pathways` -> `mmli1-worker-job-0X` (CPU)
        * `novostoic-dgpredictor` -> `mmli1-worker-job-0X` (CPU)
        * `clean` -> `mmli1-worker-job-0X` (CPU)
        * `somn` -> `mmli1-worker-job-0X` (CPU)
        * `molli` -> `mmli1-worker-job-0X` (CPU)