### PR TITLE
fix: update ChemScraper postprocessing to use new filenames and correct SVGs for 0.4.3

### DIFF
--- a/app/models/exportRequestBody.py
+++ b/app/models/exportRequestBody.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 
 class ExportRequestBody(BaseModel):
     jobId: str
+    pdf_filename: str
     cdxml: bool
     cdxml_filter: str
     cdxml_selected_pages: List[int]

--- a/app/models/exportRequestBody.py
+++ b/app/models/exportRequestBody.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 
 class ExportRequestBody(BaseModel):
     jobId: str
-    input_filename: Optional[str]
+    input_filename: str
     cdxml: bool
     cdxml_filter: str
     cdxml_selected_pages: List[int]

--- a/app/models/exportRequestBody.py
+++ b/app/models/exportRequestBody.py
@@ -1,9 +1,9 @@
-from typing import List
+from typing import List, Optional
 from pydantic import BaseModel
 
 class ExportRequestBody(BaseModel):
     jobId: str
-    pdf_filename: str
+    input_filename: Optional[str]
     cdxml: bool
     cdxml_filter: str
     cdxml_selected_pages: List[int]

--- a/app/routers/chemscraper.py
+++ b/app/routers/chemscraper.py
@@ -61,9 +61,9 @@ async def analyze_documents(requestBody: AnalyzeRequestBody, background_tasks: B
 @router.get("/chemscraper/similarity-sorted-order/{job_id}")
 def get_similarity_sorted_order(job_id: str, smile_string: str, service: MinIOService = Depends()):
     bucket_name = "chemscraper"
-    csv_content = service.get_file(bucket_name, "results/" + job_id + "/" + job_id + ".csv")
+    csv_content = service.get_file(bucket_name, "results/" + job_id + "/" + job_id + "-results.csv")
     if csv_content is None:
-        filename = "results/" + job_id + "/" + job_id + ".csv"
+        filename = "results/" + job_id + "/" + job_id + "-results.csv"
         raise HTTPException(status_code=404, detail=f"File {filename} not found")
     df = pd.read_csv(io.BytesIO(csv_content))
     # Check if sort_column exists in DataFrame

--- a/app/routers/chemscraper.py
+++ b/app/routers/chemscraper.py
@@ -61,9 +61,9 @@ async def analyze_documents(requestBody: AnalyzeRequestBody, background_tasks: B
 @router.get("/chemscraper/similarity-sorted-order/{job_id}")
 def get_similarity_sorted_order(job_id: str, smile_string: str, service: MinIOService = Depends()):
     bucket_name = "chemscraper"
-    csv_content = service.get_file(bucket_name, "results/" + job_id + "/" + job_id + "-results.csv")
+    csv_content = service.get_file(bucket_name, f"{job_id}/out/{job_id}-results.csv")
     if csv_content is None:
-        filename = "results/" + job_id + "/" + job_id + "-results.csv"
+        filename = f"{job_id}/out/{job_id}-results.csv"
         raise HTTPException(status_code=404, detail=f"File {filename} not found")
     df = pd.read_csv(io.BytesIO(csv_content))
     # Check if sort_column exists in DataFrame

--- a/app/routers/chemscraper.py
+++ b/app/routers/chemscraper.py
@@ -49,7 +49,7 @@ async def analyze_documents(requestBody: AnalyzeRequestBody, background_tasks: B
             db.add(db_job)
             await db.commit()
         except Exception as e:
-            content = {"jobId": requestBody.jobId, "error_message": "Database Error Occured.", "error_details": str(e)}
+            content = {"jobId": requestBody.jobId, "error_message": "Database Error Occurred.", "error_details": str(e)}
             return JSONResponse(content=content, status_code=400) 
 
         filename = requestBody.fileList[0]

--- a/app/routers/chemscraper.py
+++ b/app/routers/chemscraper.py
@@ -24,6 +24,7 @@ import io
 
 router = APIRouter()
 
+
 @router.post("/chemscraper/analyze", tags=['ChemScraper'])
 async def analyze_documents(requestBody: AnalyzeRequestBody, background_tasks: BackgroundTasks, service: MinIOService = Depends(), db: AsyncSession = Depends(get_session), email_service: EmailService = Depends()):
     # Analyze only one document for NSF demo
@@ -57,6 +58,7 @@ async def analyze_documents(requestBody: AnalyzeRequestBody, background_tasks: B
         background_tasks.add_task(chemscraperService.runChemscraperOnDocument, 'chemscraper', filename, objectPath, requestBody.jobId, service, email_service)
         content = {"jobId": requestBody.jobId, "submitted_at": datetime.now().isoformat()}
         return JSONResponse(content=content, status_code=status.HTTP_202_ACCEPTED)
+
 
 @router.get("/chemscraper/similarity-sorted-order/{job_id}")
 def get_similarity_sorted_order(job_id: str, smile_string: str, service: MinIOService = Depends()):
@@ -92,6 +94,7 @@ def get_similarity_sorted_order(job_id: str, smile_string: str, service: MinIOSe
     # Return the IDs from each row as a list
     return df_sorted['id'].tolist()
 
+
 @router.post("/chemscraper/flag", tags=['ChemScraper'])
 async def flag_molecule(requestBody: FlaggedMolecule, db: AsyncSession = Depends(get_session)):
     flagged_molecule = FlaggedMolecule(
@@ -109,6 +112,7 @@ async def flag_molecule(requestBody: FlaggedMolecule, db: AsyncSession = Depends
     
     content = {"success_message": "Molecule Flag Successful"}
     return JSONResponse(content=content, status_code=status.HTTP_202_ACCEPTED) 
+
 
 @router.delete("/chemscraper/flag", tags=['ChemScraper'])
 async def delete_flagged_molecule(requestBody: FlaggedMoleculeDelete, db: AsyncSession = Depends(get_session)):

--- a/app/routers/files.py
+++ b/app/routers/files.py
@@ -13,6 +13,7 @@ from starlette.responses import FileResponse
 
 from config import get_logger
 from models.exportRequestBody import ExportRequestBody
+from models.molecule import Molecule
 from models.sqlmodel.db import get_session
 
 from models.enums import JobType
@@ -27,7 +28,7 @@ from services.aceretro_service import ACERetroService
 from services.reactionminer_service import ReactionMinerService
 
 
-from typing import Optional
+from typing import Optional, List
 
 router = APIRouter()
 
@@ -113,6 +114,12 @@ def get_errors(bucket_name: str, job_id: str, service: MinIOService = Depends())
         filename = job_id + "/errors.txt"
         raise HTTPException(status_code=404, detail=f"File {filename} not found")
     return error_content
+
+
+# FIXME: Temporary workaround to force FastAPI to generate a model for Molecule
+@router.post("/{bucket_name}/exxample", tags=['Files'])
+async def delete_me() -> List[Molecule]:
+    raise HTTPException(status_code=501, detail="Not yet implemented")
 
 
 # TODO: Refactor this to make it more generic?

--- a/app/routers/files.py
+++ b/app/routers/files.py
@@ -115,8 +115,9 @@ def get_errors(bucket_name: str, job_id: str, service: MinIOService = Depends())
     return error_content
 
 
+# TODO: Refactor this to make it more generic?
 @router.post("/{bucket_name}/export-results", tags=['Files'])
-async def analyze_documents(bucket_name: str, requestBody: ExportRequestBody, service: MinIOService = Depends()):
+async def export_results(bucket_name: str, requestBody: ExportRequestBody, service: MinIOService = Depends()):
     # Analyze only one document for NSF demo
     if requestBody.jobId == "":
         raise HTTPException(status_code=404, detail="Invalid Job ID")
@@ -126,7 +127,7 @@ async def analyze_documents(bucket_name: str, requestBody: ExportRequestBody, se
         filename = f'chemscraper_{requestBody.jobId}.zip'
         with zipfile.ZipFile(filename, "w") as new_zip:
             if requestBody.cdxml:
-                pdf_filename = Path(requestBody.pdf_filename).stem
+                pdf_filename = Path(requestBody.input_filename).stem
                 if requestBody.cdxml_filter == "all_molecules":
                     object_path = objectPathPrefix + f"{pdf_filename}_full_cdxml/{pdf_filename}.cdxml"
                     cdxml_file_data = service.get_file(bucket_name, object_path)

--- a/app/routers/files.py
+++ b/app/routers/files.py
@@ -4,6 +4,7 @@ import sys
 import uuid
 import zipfile
 from datetime import datetime
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, status
 from fastapi.responses import JSONResponse
@@ -125,19 +126,20 @@ async def analyze_documents(bucket_name: str, requestBody: ExportRequestBody, se
         filename = f'chemscraper_{requestBody.jobId}.zip'
         with zipfile.ZipFile(filename, "w") as new_zip:
             if requestBody.cdxml:
+                pdf_filename = Path(requestBody.pdf_filename).stem
                 if requestBody.cdxml_filter == "all_molecules":
-                    object_path = objectPathPrefix + "molecules_full_cdxml/molecules.cdxml"
+                    object_path = objectPathPrefix + f"{pdf_filename}_full_cdxml/{pdf_filename}.cdxml"
                     cdxml_file_data = service.get_file(bucket_name, object_path)
                     if cdxml_file_data is None:
-                        filename = objectPathPrefix + "molecules_full_cdxml/molecules.cdxml"
+                        filename = objectPathPrefix + f"{pdf_filename}_full_cdxml/{pdf_filename}.cdxml"
                         raise HTTPException(status_code=404, detail=f"File {filename} not found")
                     new_zip.writestr(requestBody.jobId + ".cdxml", cdxml_file_data)
                     files_count += 1
                 elif requestBody.cdxml_filter == "single_page" and len(requestBody.cdxml_selected_pages) > 0:
                     cdxml_file_data = service.get_file(bucket_name,
-                                                       objectPathPrefix + "molecules_all_pages/Page_" + f"{requestBody.cdxml_selected_pages[0]:03d}" + ".cdxml")
+                                                       objectPathPrefix + f"{pdf_filename}_all_pages/Page_{requestBody.cdxml_selected_pages[0]:03d}" + ".cdxml")
                     if cdxml_file_data is None:
-                        filename = objectPathPrefix + "molecules_all_pages/Page_" + f"{requestBody.cdxml_selected_pages[0]:03d}" + ".cdxml"
+                        filename = objectPathPrefix + f"{pdf_filename}_all_pages/Page_" + f"{requestBody.cdxml_selected_pages[0]:03d}" + ".cdxml"
                         raise HTTPException(status_code=404, detail=f"File {filename} not found")
                     new_zip.writestr(requestBody.jobId + "_Page_" + f"{requestBody.cdxml_selected_pages[0]:03d}" + ".cdxml",
                                      cdxml_file_data)

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -59,10 +59,14 @@ async def create_job(
     # Validate Job type
     # TODO: Set command+image based on job_type
     if job_type == JobType.CHEMSCRAPER:
-        log.debug("Creating CHEMSCRAPER job")
+        raise HTTPException(status_code=501, detail=f"job_type={job_type} is not yet supported by the Jobs API")
+
+        # TODO: Create a simple job container for executing ChemScraper HTTP requests
+
+        #log.debug("Creating CHEMSCRAPER job")
         # runs as a background_task
-        command = 'N/A'
-        image_name = 'N/A'
+        #command = 'N/A'
+        #image_name = 'N/A'
     elif job_type in JobTypes:
         log.debug(f"Creating Kubernetes job: {job_type}")
         # runs in Kubernetes, read Docker image name from config

--- a/app/services/chemscraper_service.py
+++ b/app/services/chemscraper_service.py
@@ -127,8 +127,14 @@ class ChemScraperService:
                     # Only molecules having all these fields available are processed
                     SMILE_LIST.append(SMILE)
                     svg_filename = f"Page_{page_no.zfill(3)}_No{row[1].zfill(3)}.svg"
-                    pdf_filename = Path(file_path).stem
-                    log.info(f'Using file stem: {pdf_filename}')
+                    # FIXME: Remove this wrokaround in the future
+                    # FIXME: it shouldn't be needed once the file_path format is correct in the CSV
+                    pdf_filepath = file_path.split('detected=')[0].rstrip()
+                    log.debug(f'Using file stem: {pdf_filepath}')
+                    pdf_filename = Path(pdf_filepath).stem
+                    log.debug(f'Using file stem: {pdf_filename}')
+                    log.debug(f'Processing row:   doc_no={doc_no}   file_path={file_path}   page_no={page_no}   SMILE={SMILE}    X={minX}:{maxX}    Y={minY}:{maxY}')
+
                     obj_path = f'{jobId}/out/{pdf_filename}/{svg_filename}'
                     log.info(f'Attempting to read SVG from ChemScraper output: {bucket_name}/{obj_path}')
                     SVG = service.get_file(bucket_name, obj_path)

--- a/app/services/chemscraper_service.py
+++ b/app/services/chemscraper_service.py
@@ -30,6 +30,7 @@ from models.sqlmodel.models import FlaggedMolecule
 
 log = get_logger(__name__)
 
+
 class ChemScraperService:
     chemscraper_api_baseURL = app_config['external']['chemscraper']['apiBaseUrl']
     chemscraper_frontend_baseURL = app_config['external']['chemscraper']['frontendBaseUrl']
@@ -127,6 +128,7 @@ class ChemScraperService:
                     SMILE_LIST.append(SMILE)
                     svg_filename = f"Page_{page_no.zfill(3)}_No{row[1].zfill(3)}.svg"
                     pdf_filename = Path(file_path).stem
+                    log.info(f'Using file stem: {pdf_filename}')
                     obj_path = f'{jobId}/out/{pdf_filename}/{svg_filename}'
                     log.info(f'Attempting to read SVG from ChemScraper output: {bucket_name}/{obj_path}')
                     SVG = service.get_file(bucket_name, obj_path)
@@ -221,7 +223,6 @@ class ChemScraperService:
         if not upload_result:
             raise HTTPException(status_code=500, detail="Unable to store CSV")
         return
-
 
     async def runChemscraperOnDocument(self, bucket_name: str, filename: str, objectPath: str, jobId: str, service: MinIOService, email_service: EmailService):
         # Get Job Object

--- a/app/services/chemscraper_service.py
+++ b/app/services/chemscraper_service.py
@@ -47,7 +47,7 @@ class ChemScraperService:
         await self.db.commit()
 
     @staticmethod
-    async def resultPostProcess(bucket_name: str, job_id: str, service: MinIOService, db: AsyncSession):
+    async def resultPostProcess(bucket_name: str, job_id: str, service: MinIOService, db: AsyncSession) -> List[Molecule]:
         rdkitService = RDKitService()
         csv_filepath = job_id + "/out/" + job_id + "-results.csv"
         csv_content = service.get_file(bucket_name, csv_filepath)

--- a/app/services/chemscraper_service.py
+++ b/app/services/chemscraper_service.py
@@ -120,7 +120,7 @@ class ChemScraperService:
                 doc_no, full_metadata = row[1], row[2]
 
                 # Parse full metadata into file_path, version, and stat counters
-                pattern = r"(?P<file_path>.+) detected=(?P<num_detected>.+) parsed=(?P<num_converted>.+) converted=(?P<num_converted>.+) version=(?P<version>.+)"
+                pattern = r"(?P<file_path>.+) detected=(?P<num_detected>.+) parsed=(?P<num_parsed>.+) converted=(?P<num_converted>.+) version=(?P<version>.+)"
                 match = re.match(pattern, row[2])
                 if match:
                     file_path = match.group('file_path')
@@ -132,9 +132,16 @@ class ChemScraperService:
                     #version = match.group('version')
 
             if row[0] == "P":
+                # Format: P	1	1000	1000
                 page_no = row[1]
 
+            # Ignored for now?
+            if row[0] == "FR":
+                # Format: FR	2	825	1950	1020	2056
+                continue
+
             if row[0] == "SMI":
+                # Format: SMI	1	COC(=O)C*	1609	1949	1810	2057
                 SMILE = row[2]
                 minX, minY, maxX, maxY = map(int, row[3:7])
                 if all([doc_no, file_path, page_no, SMILE, minX, minY, maxX, maxY]):

--- a/app/services/chemscraper_service.py
+++ b/app/services/chemscraper_service.py
@@ -128,7 +128,9 @@ class ChemScraperService:
                     svg_filename = f"Page_{page_no.zfill(3)}_No{row[1].zfill(3)}.svg"
                     pdf_filename = Path(file_path).stem
                     SVG = service.get_file(bucket_name, f'{jobId}/out/{pdf_filename}/{svg_filename}')
-                    if SVG is None:
+                    if SVG is not None:
+                        log.info('Using SVG from ChemScraper output!')
+                    else:
                         log.warning("SVG not found, generating using rdkit")
                         SVG = rdkitService.renderSVGFromSMILE(smileString=SMILE)
 

--- a/app/services/chemscraper_service.py
+++ b/app/services/chemscraper_service.py
@@ -8,6 +8,7 @@ import csv
 import zipfile
 import time
 import pandas as pd
+from pathlib import Path
 from io import StringIO
 
 from config import get_logger, app_config
@@ -125,7 +126,8 @@ class ChemScraperService:
                     # Only molecules having all these fields available are processed
                     SMILE_LIST.append(SMILE)
                     svg_filename = f"Page_{page_no.zfill(3)}_No{row[1].zfill(3)}.svg"
-                    SVG = service.get_file(bucket_name, jobId + '/out/molecules/' + svg_filename)
+                    pdf_filename = Path(file_path).stem
+                    SVG = service.get_file(bucket_name, f'{jobId}/out/{pdf_filename}/{svg_filename}')
                     if SVG is None:
                         log.warning("SVG not found, generating using rdkit")
                         SVG = rdkitService.renderSVGFromSMILE(smileString=SMILE)

--- a/app/services/chemscraper_service.py
+++ b/app/services/chemscraper_service.py
@@ -127,7 +127,9 @@ class ChemScraperService:
                     SMILE_LIST.append(SMILE)
                     svg_filename = f"Page_{page_no.zfill(3)}_No{row[1].zfill(3)}.svg"
                     pdf_filename = Path(file_path).stem
-                    SVG = service.get_file(bucket_name, f'{jobId}/out/{pdf_filename}/{svg_filename}')
+                    obj_path = f'{jobId}/out/{pdf_filename}/{svg_filename}'
+                    log.info(f'Attempting to read SVG from ChemScraper output: {bucket_name}/{obj_path}')
+                    SVG = service.get_file(bucket_name, obj_path)
                     if SVG is not None:
                         log.info('Using SVG from ChemScraper output!')
                     else:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   postgresql:
     container_name: mmli-backend-postgresql
@@ -61,7 +60,7 @@ services:
 
 networks:
   mmli-net:
-    external: true
+    #external: true
     name: mmli-net
 
 volumes:


### PR DESCRIPTION
## Problems
* The path to some of the ChemScraper output files have changed - this breaks Export Results + Similarity Sorting

> The files returned by the chemscraper container are now:
> `locations.tsv`,  `pdf_filename`, `pdf_filename_all_pages`,  `pdf_filename_full_cdxml`
> where `pdf_filename` is the input filename of the pdf uploaded
> 
> Before, it was:
> `locations.tsv`,  `molecules`, `molecules_all_pages`,  `molecules_full_cdxml`
> where `molecules` was used for all pdf files

The backend needs to account for this when running its postprocessing step for these jobs

* All Extracted Structures are rendering the wrong SVG images

Additionally, we want to make sure that we are rendering the SVG images that are produced by ChemScraper when possible

Relates to https://github.com/moleculemaker/chemscraper-frontend/pull/109

## Approach
* fix: update ChemScraper postprocessing to use new filenames for 0.4.3 when parsing SVG structures
* fix: update ChemScraper export-results to use new result file paths (added optional `input_filename` parameter that frontend needs to send)
* HACK: Molecule model wasn't being generated properly (since it is not technically an explicit input or output of any endpoint), so I created a fake endpoint there that return a List of Molecules to ensure that the model is generated
* fix: parse additional metadata out of file_path field to fix SVG rendering issue

FUTURE: we should rework ChemScraper jobs to run in Kubernetes - that way, it is easier to adjust/replace/redeploy this postprocessing code without bringing down the rest of the API server and jobs are not interrupted in the API needs to come down for maintenance or deployment reasons

## How to Test
See [frontend PR](https://github.com/moleculemaker/chemscraper-frontend/pull/109) for additional test cases

### SVG Generation
1. Navigate to https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu/configuration
2. Upload a PDF and run a new job - this is important, as postprocessing is only run immediately after a job completes
3. View the results of the job you just ran
    * You should see the results page for the processed PDF
    * You should see a table of all molecule structures scraped from the input PDF
    * You should see that an image appears under both Extracted Structure and Original Structure for all molecules
    * You should see that the Extracted Structure SVG image matches the SVG file in MinIO for that document + page number - this confirms that the SVG being rendered in the frontend is the one that was produced by ChemScraper
4. Expand a row by clicking on it
    * You should see that more verbose details about the chosen molecule are shown
    * You should see that an image appears under both Extracted Structure and Original Structure for this molecule
    * The two SVG images for Extracted Structure (the one on the table row and the one within the expanded row details) should be the exact same image
5. Repeat with other molecules in this PDF
6. Repeat with other PDFs

### Similarity Sorting
1. View the results of a finished job: https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu/results/235ee623b6274f3eb05606a0aa2b09da
    * You should see the results page for the processed PDF
    * You should see a table of all molecule structures scraped from the input PDF
2. Expand a row by clicking on it
    * You should see that more verbose details about the chosen molecule are shown
3. Click on "View Similar Structures" to trigger similarity sorting
    * You should see that the search results are filtered to show only structures similar to the one that you chose
    * You should not see an error appear on screen

### Export Results
1. View the results of a finished job: https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu/results/235ee623b6274f3eb05606a0aa2b09da
    * You should see the results page for the processed PDF
    * You should see a table of all molecule structures scraped from the input PDF
2. At the top-right choose export - try out all 4 options
    * For each option, you should see that a file is downloaded for each case