### PR TITLE
[WIP] feat: first attempt at ChemScraper k8s job

### DIFF
--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -65,6 +65,31 @@ kubernetes_jobs:
       requests:
         cpu: "2"
         memory: 12Gi
+
+  # Config for running ChemScraper job
+  chemscraper:
+    image: moleculemaker/chemscraper-job:latest
+    imagePullPolicy: Always
+    env:
+      - name: LOG_LEVEL
+        value: DEBUG
+      - name: CHEMSCRAPER_BASE_URL
+        value: 'https://chemscraper.backend.staging.mmli1.ncsa.illinois.edu'
+    nodeSelector:
+      ncsa.role: worker-job
+    tolerations:
+      - effect: NoSchedule
+        key: mmli.role
+        operator: Exists
+    volumes:
+      - claimName: mmli-clean-job-weights
+        mountPath: /usr/app/inputs/
+        name: shared-storage
+        subPath: uws/jobs/chemscraper/JOB_ID/in
+      - claimName: mmli-clean-job-weights
+        mountPath: /usr/app/outputs/
+        name: shared-storage
+        subPath: uws/jobs/chemscraper/JOB_ID/out
   
   # Config for running CLEAN job
   clean:

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -58,16 +58,7 @@ async def create_job(
 
     # Validate Job type
     # TODO: Set command+image based on job_type
-    if job_type == JobType.CHEMSCRAPER:
-        raise HTTPException(status_code=501, detail=f"job_type={job_type} is not yet supported by the Jobs API")
-
-        # TODO: Create a simple job container for executing ChemScraper HTTP requests
-
-        #log.debug("Creating CHEMSCRAPER job")
-        # runs as a background_task
-        #command = 'N/A'
-        #image_name = 'N/A'
-    elif job_type in JobTypes:
+    if job_type in JobTypes:
         log.debug(f"Creating Kubernetes job: {job_type}")
         # runs in Kubernetes, read Docker image name from config
         image_name = app_config['kubernetes_jobs'][job_type]['image']
@@ -84,6 +75,19 @@ async def create_job(
             command = app_config['kubernetes_jobs'][job_type]['command']
             #command = f'ls -al /uws/jobs/{job_type}/{job_id}'
 
+        elif job_type == JobType.CHEMSCRAPER:
+            log.debug(f"Creating Kubernetes job: {job_type}")
+
+            job_config = json.loads(job_info.replace('\"', '"'))
+            if 'input_file' not in job_config:
+                raise HTTPException(status_code=400, detail='"job_info" requires "input_file" for ChemScraper jobs')
+
+            environment = [
+                {
+                    'name': 'CHEMSCRAPER_INPUT_FILE',
+                    'value': job_config['input_file']
+                }
+            ]
         elif job_type == JobType.ACERETRO:
             # ACERetro jobs
             # Example usage:

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -80,6 +80,17 @@ config:
         requests:
           cpu: "1"
           memory: 8Gi
+    chemscraper:
+      image: moleculemaker/chemscraper-job:main
+      env:
+        - name: CHEMSCRAPER_BASE_URL
+          value: 'http://chemscraper-services.alphasynthesis.svc.cluster.local:8000'
+      nodeSelector:
+        ncsa.role: worker-job
+      tolerations:
+        - effect: NoSchedule
+          key: mmli.role
+          operator: Exists
     clean:
       nodeSelector:  
         ncsa.role: worker-job  

--- a/chart/values.staging.yaml
+++ b/chart/values.staging.yaml
@@ -67,6 +67,18 @@ config:
       - effect: NoSchedule  
         key: mmli.role  
         operator: Exists
+    chemscraper:
+      env:
+        - name: LOG_LEVEL
+          value: DEBUG
+        - name: CHEMSCRAPER_BASE_URL
+          value: 'http://chemscraper-services-staging.staging.svc.cluster.local:8000'
+      nodeSelector:
+        ncsa.role: worker-job
+      tolerations:
+      - effect: NoSchedule
+        key: mmli.role
+        operator: Exists
     clean:
       nodeSelector:  
         ncsa.role: worker-job  
@@ -102,6 +114,7 @@ config:
         - effect: NoSchedule
           key: nvidia.com/gpu
           operator: Exists
+
   minio:
     server: "mmli-backend-staging-minio.staging.svc.cluster.local:9000"
     apiBaseUrl: "minioapi.mmli.fastapi.staging.mmli1.ncsa.illinois.edu"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -131,6 +131,23 @@ config:
           cpu: "2"
           memory: 12Gi
 
+    # Config for running ChemScraper job
+    chemscraper:
+      image: moleculemaker/chemscraper-job:latest
+      imagePullPolicy: Always
+      env:
+        - name: CHEMSCRAPER_BASE_URL
+          value: 'https://chemscraper.backend.staging.mmli1.ncsa.illinois.edu'
+      volumes:
+        - claimName: mmli-clean-job-weights
+          mountPath: /usr/app/inputs/
+          name: shared-storage
+          subPath: uws/jobs/chemscraper/JOB_ID/in
+        - claimName: mmli-clean-job-weights
+          mountPath: /usr/app/outputs/
+          name: shared-storage
+          subPath: uws/jobs/chemscraper/JOB_ID/out
+
     # Config for running CLEAN job
     clean:
       image: "moleculemaker/clean-image-amd64:latest"


### PR DESCRIPTION
## Problem
ChemScraper is the only job that does not run under Kubernetes

Running it under Kubernetes would yield the following benefits:
* Increased resilience against restarts of `mmli-backend` API server
* Isolated logs, more log details, easier to follow the logs of an individual job
* Automatic handling of input download + output upload
* Automatic handling of sent emails using the same system we use for other job types
* Better consistency across all AlphaSynthesis job types

Fixes #81 

## Approach
* feat: first attempt at ChemScraper k8s job
    * uses generated Python client for the ChemScraper API (borrowed from ReactionMiner job)
        * NOTE: one minor manual hack was needed to successfully return a ZIP file response
        * See https://github.com/moleculemaker/chemscraper-helm-chart/blob/373d18594314862d4aee173fcb271801f2ef4594/job/chemscraper/fast_api_client/api/default/extract_extract_pdf_post.py#L44-L49
    * uses post-processing code from [app/services/chemscraper_service.py](https://github.com/moleculemaker/mmli-backend/blob/main/app/services/chemscraper_service.py#L106-L293)

## How to Test
TBD