### PR TITLE
feat: run OED jobs via API - dlkcat + unikp + catpred

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ chart/charts/
 !app/cfg/secret.yaml
 
 */sql_app.db
+.idea/

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -169,7 +169,10 @@ kubernetes_jobs:
         name: shared-storage
         subPath: uws/jobs/oed-catpred/.pretrained
         claimName: 'mmli-clean-job-weights'
-
+      - mountPath: /catpred_pipeline/catpred/production_models
+        name: shared-storage
+        subPath: uws/jobs/oed-catpred/.pretrained/pretrained/production
+        claimName: 'mmli-clean-job-weights'
   # Config for running ReactionMiner job
   reactionminer:
     image: "moleculemaker/reactionminer:latest"

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -173,6 +173,9 @@ kubernetes_jobs:
         name: shared-storage
         subPath: uws/jobs/oed-catpred/.pretrained/pretrained/production
         claimName: 'mmli-clean-job-weights'
+        name: shared-storage
+        subPath: uws/jobs/oed-catpred/.pretrained/pretrained/production
+        claimName: 'mmli-clean-job-weights'
   # Config for running ReactionMiner job
   reactionminer:
     image: "moleculemaker/reactionminer:latest"

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -30,6 +30,7 @@ somn_frontend_url: "https://somn.frontend.staging.mmli1.ncsa.illinois.edu"
 clean_frontend_url: "https://clean.frontend.staging.mmli1.ncsa.illinois.edu"
 molli_frontend_url: "https://molli.frontend.staging.mmli1.ncsa.illinois.edu"
 aceretro_frontend_url: "https://aceretro.frontend.staging.mmli1.ncsa.illinois.edu"
+openenzymedb_frontend_url: "https://frontend.staging.openenzymedb.mmli1.ncsa.illinois.edu"
 
 kubernetes_jobs:
   aceretro:

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -134,6 +134,25 @@ kubernetes_jobs:
         mountPath: '/uws/jobs/oed-unikp/JOB_ID/out'
         subPath: 'uws/jobs/oed-unikp/JOB_ID/out'
         claimName: 'mmli-clean-job-weights'
+      - mountPath: /root/.cache/huggingface/hub
+        name: shared-storage
+        subPath: uws/jobs/oed-unikp/.cache
+        claimName: 'mmli-clean-job-weights'
+      - mountPath: /usr/app/UniKP
+        name: shared-storage
+        subPath: uws/jobs/oed-unikp/.models
+        claimName: 'mmli-clean-job-weights'
+    secrets:
+      - mountPath: '/root/.cache/token'
+        name: 'token'
+        subPath: 'token'
+        readOnly: 'true'
+        secretName: huggingface-token
+        # "itemList" takes the place of "items"
+        # This should avoid overlap with the built-in items() function
+        itemList:
+          - key: token
+            path: token
   oed-catpred:
     image: 'moleculemaker/oed-catpred'
     imagePullPolicy: 'Always'
@@ -145,6 +164,10 @@ kubernetes_jobs:
       - name: 'shared-storage'
         mountPath: '/uws/jobs/oed-catpred/JOB_ID/out'
         subPath: 'uws/jobs/oed-catpred/JOB_ID/out'
+        claimName: 'mmli-clean-job-weights'
+      - mountPath: /data
+        name: shared-storage
+        subPath: uws/jobs/oed-unikp/.pretrained
         claimName: 'mmli-clean-job-weights'
 
   # Config for running ReactionMiner job

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -165,7 +165,7 @@ kubernetes_jobs:
         mountPath: '/uws/jobs/oed-catpred/JOB_ID/out'
         subPath: 'uws/jobs/oed-catpred/JOB_ID/out'
         claimName: 'mmli-clean-job-weights'
-      - mountPath: /data
+      - mountPath: /catpred_pipeline/data
         name: shared-storage
         subPath: uws/jobs/oed-catpred/.pretrained
         claimName: 'mmli-clean-job-weights'

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -109,6 +109,44 @@ kubernetes_jobs:
         subPath: 'weights'
         claimName: 'mmli-clean-job-weights'
 
+  # Config for running OpenEnzymeDB job(s)
+  oed-dlkcat:
+    image: 'moleculemaker/oed-dlkcat-dla'
+    imagePullPolicy: 'Always'
+    volumes:
+      - name: 'shared-storage'
+        mountPath: '/uws/jobs/oed-dlkcat/JOB_ID/in'
+        subPath: 'uws/jobs/oed-dlkcat/JOB_ID/in'
+        claimName: 'mmli-clean-job-weights'
+      - name: 'shared-storage'
+        mountPath: '/uws/jobs/oed-dlkcat/JOB_ID/out'
+        subPath: 'uws/jobs/oed-dlkcat/JOB_ID/out'
+        claimName: 'mmli-clean-job-weights'
+  oed-unikp:
+    image: 'moleculemaker/oed-unikp'
+    imagePullPolicy: 'Always'
+    volumes:
+      - name: 'shared-storage'
+        mountPath: '/uws/jobs/oed-unikp/JOB_ID/in'
+        subPath: 'uws/jobs/oed-unikp/JOB_ID/in'
+        claimName: 'mmli-clean-job-weights'
+      - name: 'shared-storage'
+        mountPath: '/uws/jobs/oed-unikp/JOB_ID/out'
+        subPath: 'uws/jobs/oed-unikp/JOB_ID/out'
+        claimName: 'mmli-clean-job-weights'
+  oed-catpred:
+    image: 'moleculemaker/oed-catpred'
+    imagePullPolicy: 'Always'
+    volumes:
+      - name: 'shared-storage'
+        mountPath: '/uws/jobs/oed-catpred/JOB_ID/in'
+        subPath: 'uws/jobs/oed-catpred/JOB_ID/in'
+        claimName: 'mmli-clean-job-weights'
+      - name: 'shared-storage'
+        mountPath: '/uws/jobs/oed-catpred/JOB_ID/out'
+        subPath: 'uws/jobs/oed-catpred/JOB_ID/out'
+        claimName: 'mmli-clean-job-weights'
+
   # Config for running ReactionMiner job
   reactionminer:
     image: "moleculemaker/reactionminer:latest"

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -167,7 +167,7 @@ kubernetes_jobs:
         claimName: 'mmli-clean-job-weights'
       - mountPath: /data
         name: shared-storage
-        subPath: uws/jobs/oed-unikp/.pretrained
+        subPath: uws/jobs/oed-catpred/.pretrained
         claimName: 'mmli-clean-job-weights'
 
   # Config for running ReactionMiner job

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -12,6 +12,9 @@ class JobType(str, Enum):
     NOVOSTOIC_DGPREDICTOR = 'novostoic-dgpredictor'
     REACTIONMINER = 'reactionminer'
     SOMN = 'somn'
+    OED_DLKCAT = 'oed-dlkcat'
+    OED_UNIKP = 'oed-unikp'
+    OED_CATPRED = 'oed-catpred'
     DEFAULT = 'defaults'
 
     def __str__(self) -> str:

--- a/app/routers/files.py
+++ b/app/routers/files.py
@@ -26,6 +26,7 @@ from services.minio_service import MinIOService
 from services.chemscraper_service import ChemScraperService
 from services.aceretro_service import ACERetroService
 from services.reactionminer_service import ReactionMinerService
+from services.openenzymedb_service import OpenEnzymeDBService
 
 
 from typing import Optional, List
@@ -93,6 +94,9 @@ async def get_results(bucket_name: str, job_id: str, service: MinIOService = Dep
 
     elif bucket_name == JobType.SOMN:
         return await SomnService.resultPostProcess(bucket_name, job_id, service, db)
+
+    elif bucket_name == JobType.OED_DLKCAT or bucket_name == JobType.OED_UNIKP or bucket_name == JobType.OED_CATPRED:
+        return await OpenEnzymeDBService.resultPostProcess(bucket_name, job_id, service, db)
 
     else:
         raise HTTPException(status_code=400, detail="Invalid job type: " + bucket_name)

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -127,6 +127,12 @@ async def create_job(
         elif job_type == JobType.REACTIONMINER:
             log.debug(f'Running ReactionMiner job: {job_id}')
             environment = app_config['kubernetes_jobs']['reactionminer']['env']
+
+        elif job_type == JobType.OED_DLKCAT or job_type == JobType.OED_UNIKP or job_type == JobType.OED_CATPRED:
+            # Example: "job_info": "{\"input_pairs\":[{\"name\":\"example\",\"sequence\":\"MEDIPDTSRPPLKYVK...\",\"type\":\"FASTA\",\"smiles\":\"OC1=CC=C(C[C@@H](C(O)=O)N)C=C1\"}]}"
+            log.debug(f'Running OpenEnzymeDB job: {job_type} - {job_id}')
+            environment = [{'OED_JOB_INFO': json.dumps(job_info)}]
+
         elif job_type == JobType.SOMN:
             #  Build up example_request.csv from user input, upload to MinIO?
             job_config = json.loads(job_info.replace('\"', '"'))

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -131,11 +131,13 @@ async def create_job(
         elif job_type == JobType.OED_DLKCAT or job_type == JobType.OED_UNIKP or job_type == JobType.OED_CATPRED:
             # Example: "job_info": "{\"input_pairs\":[{\"name\":\"example\",\"sequence\":\"MEDIPDTSRPPLKYVK...\",\"type\":\"FASTA\",\"smiles\":\"OC1=CC=C(C[C@@H](C(O)=O)N)C=C1\"}]}"
             log.debug(f'Running OpenEnzymeDB job: {job_type} - {job_id}')
-            environment = [{'name': 'OED_JOB_INFO', 'value': json.dumps(job_info.replace('\\"', '"'))}]
+            json_str = job_info.replace('\"', '"')
+            environment = [{'name': 'OED_JOB_INFO', 'value': json.dumps(json_str)}]
 
         elif job_type == JobType.SOMN:
             #  Build up example_request.csv from user input, upload to MinIO?
-            job_config = json.loads(job_info.replace('\"', '"'))
+            json_str = job_info.replace('\"', '"')
+            job_config = json.loads(json_str)
             
             # Canonicalize SMILES and update names from reference files
             for config in job_config:

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -131,7 +131,7 @@ async def create_job(
         elif job_type == JobType.OED_DLKCAT or job_type == JobType.OED_UNIKP or job_type == JobType.OED_CATPRED:
             # Example: "job_info": "{\"input_pairs\":[{\"name\":\"example\",\"sequence\":\"MEDIPDTSRPPLKYVK...\",\"type\":\"FASTA\",\"smiles\":\"OC1=CC=C(C[C@@H](C(O)=O)N)C=C1\"}]}"
             log.debug(f'Running OpenEnzymeDB job: {job_type} - {job_id}')
-            environment = [{'name': 'OED_JOB_INFO', 'value': json.dumps(job_info)}]
+            environment = [{'name': 'OED_JOB_INFO', 'value': json.dumps(job_info.replace('\\"', '"'))}]
 
         elif job_type == JobType.SOMN:
             #  Build up example_request.csv from user input, upload to MinIO?

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -134,8 +134,8 @@ async def create_job(
             log.debug(f'    job_info: {job_info}')
             job_config = json.loads(job_info.replace('\"', '"'))
             log.debug(f'    job_config: {job_config}')
-            job_config_str = json.dumps(job_config)
-            environment = [{'name': 'OED_JOB_INFO', 'value': f'{job_config_str}'}]
+            job_config_str = json.dumps(job_config['input_pairs'])
+            environment = [{'name': 'OED_INPUT_PAIRS', 'value': job_config_str}]
             log.debug(f'    environment: {environment}')
 
         elif job_type == JobType.SOMN:

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -131,7 +131,7 @@ async def create_job(
         elif job_type == JobType.OED_DLKCAT or job_type == JobType.OED_UNIKP or job_type == JobType.OED_CATPRED:
             # Example: "job_info": "{\"input_pairs\":[{\"name\":\"example\",\"sequence\":\"MEDIPDTSRPPLKYVK...\",\"type\":\"FASTA\",\"smiles\":\"OC1=CC=C(C[C@@H](C(O)=O)N)C=C1\"}]}"
             log.debug(f'Running OpenEnzymeDB job: {job_type} - {job_id}')
-            environment = [{'OED_JOB_INFO': json.dumps(job_info)}]
+            environment = [{'name': 'OED_JOB_INFO', 'value': json.dumps(job_info)}]
 
         elif job_type == JobType.SOMN:
             #  Build up example_request.csv from user input, upload to MinIO?

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -131,9 +131,13 @@ async def create_job(
         elif job_type == JobType.OED_DLKCAT or job_type == JobType.OED_UNIKP or job_type == JobType.OED_CATPRED:
             # Example: "job_info": "{\"input_pairs\":[{\"name\":\"example\",\"sequence\":\"MEDIPDTSRPPLKYVK...\",\"type\":\"FASTA\",\"smiles\":\"OC1=CC=C(C[C@@H](C(O)=O)N)C=C1\"}]}"
             log.debug(f'Running OpenEnzymeDB job: {job_type} - {job_id}')
+            log.debug(f'    job_info: {job_info}')
             json_str = job_info.replace('\"', '"')
+            log.debug(f'    json_str: {json_str}')
             json_obj = json.loads(json_str)
+            log.debug(f'    json_obj: {json_obj}')
             environment = [{'name': 'OED_JOB_INFO', 'value': json.dumps(json_obj)}]
+            log.debug(f'    environment: {environment}')
 
         elif job_type == JobType.SOMN:
             #  Build up example_request.csv from user input, upload to MinIO?

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -132,7 +132,8 @@ async def create_job(
             # Example: "job_info": "{\"input_pairs\":[{\"name\":\"example\",\"sequence\":\"MEDIPDTSRPPLKYVK...\",\"type\":\"FASTA\",\"smiles\":\"OC1=CC=C(C[C@@H](C(O)=O)N)C=C1\"}]}"
             log.debug(f'Running OpenEnzymeDB job: {job_type} - {job_id}')
             json_str = job_info.replace('\"', '"')
-            environment = [{'name': 'OED_JOB_INFO', 'value': json_str}]
+            json_obj = json.loads(json_str)
+            environment = [{'name': 'OED_JOB_INFO', 'value': json.dumps(json_obj)}]
 
         elif job_type == JobType.SOMN:
             #  Build up example_request.csv from user input, upload to MinIO?

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -135,7 +135,7 @@ async def create_job(
             job_config = json.loads(job_info.replace('\\"', '"'))
             log.debug(f'    job_config: {job_config}')
             job_config_str = json.dumps(job_config['input_pairs']).replace('"', '\\"')
-            environment = [{'name': 'OED_INPUT_PAIRS', 'value': job_info}]
+            environment = [{'name': 'OED_INPUT_PAIRS', 'value': job_info.replace('"', '\\"')}]
             log.debug(f'    environment: {environment}')
 
         elif job_type == JobType.SOMN:

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -132,11 +132,7 @@ async def create_job(
             # Example: "job_info": "{\"input_pairs\":[{\"name\":\"example\",\"sequence\":\"MEDIPDTSRPPLKYVK...\",\"type\":\"FASTA\",\"smiles\":\"OC1=CC=C(C[C@@H](C(O)=O)N)C=C1\"}]}"
             log.debug(f'Running OpenEnzymeDB job: {job_type} - {job_id}')
             log.debug(f'    job_info: {job_info}')
-            json_str = job_info.replace('\"', '"')
-            log.debug(f'    json_str: {json_str}')
-            json_obj = json.loads(json_str)
-            log.debug(f'    json_obj: {json_obj}')
-            environment = [{'name': 'OED_JOB_INFO', 'value': json.dumps(json_obj)}]
+            environment = [{'name': 'OED_JOB_INFO', 'value': job_info}]
             log.debug(f'    environment: {environment}')
 
         elif job_type == JobType.SOMN:

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -132,7 +132,10 @@ async def create_job(
             # Example: "job_info": "{\"input_pairs\":[{\"name\":\"example\",\"sequence\":\"MEDIPDTSRPPLKYVK...\",\"type\":\"FASTA\",\"smiles\":\"OC1=CC=C(C[C@@H](C(O)=O)N)C=C1\"}]}"
             log.debug(f'Running OpenEnzymeDB job: {job_type} - {job_id}')
             log.debug(f'    job_info: {job_info}')
-            environment = [{'name': 'OED_JOB_INFO', 'value': job_info}]
+            job_config = json.loads(job_info.replace('\"', '"'))
+            log.debug(f'    job_config: {job_config}')
+            job_config_str = json.dumps(job_config)
+            environment = [{'name': 'OED_JOB_INFO', 'value': f'{job_config_str}'}]
             log.debug(f'    environment: {environment}')
 
         elif job_type == JobType.SOMN:

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -132,7 +132,7 @@ async def create_job(
             # Example: "job_info": "{\"input_pairs\":[{\"name\":\"example\",\"sequence\":\"MEDIPDTSRPPLKYVK...\",\"type\":\"FASTA\",\"smiles\":\"OC1=CC=C(C[C@@H](C(O)=O)N)C=C1\"}]}"
             log.debug(f'Running OpenEnzymeDB job: {job_type} - {job_id}')
             log.debug(f'    job_info: {job_info}')
-            job_config = json.loads(job_info.replace('\"', '"'))
+            job_config = json.loads(job_info.replace('\\"', '"'))
             log.debug(f'    job_config: {job_config}')
             job_config_str = json.dumps(job_config['input_pairs'])
             environment = [{'name': 'OED_INPUT_PAIRS', 'value': job_config_str}]

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -132,7 +132,7 @@ async def create_job(
             # Example: "job_info": "{\"input_pairs\":[{\"name\":\"example\",\"sequence\":\"MEDIPDTSRPPLKYVK...\",\"type\":\"FASTA\",\"smiles\":\"OC1=CC=C(C[C@@H](C(O)=O)N)C=C1\"}]}"
             log.debug(f'Running OpenEnzymeDB job: {job_type} - {job_id}')
             json_str = job_info.replace('\"', '"')
-            environment = [{'name': 'OED_JOB_INFO', 'value': json.dumps(json_str)}]
+            environment = [{'name': 'OED_JOB_INFO', 'value': json_str}]
 
         elif job_type == JobType.SOMN:
             #  Build up example_request.csv from user input, upload to MinIO?

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -134,8 +134,8 @@ async def create_job(
             log.debug(f'    job_info: {job_info}')
             job_config = json.loads(job_info.replace('\\"', '"'))
             log.debug(f'    job_config: {job_config}')
-            job_config_str = json.dumps(job_config['input_pairs'])
-            environment = [{'name': 'OED_INPUT_PAIRS', 'value': job_config_str}]
+            job_config_str = json.dumps(job_config['input_pairs']).replace('"', '\\"')
+            environment = [{'name': 'OED_INPUT_PAIRS', 'value': job_info}]
             log.debug(f'    environment: {environment}')
 
         elif job_type == JobType.SOMN:

--- a/app/services/kubejob_service.py
+++ b/app/services/kubejob_service.py
@@ -132,7 +132,18 @@ class KubeEventWatcher:
     def send_notification_email(self, updated_job, new_phase):
         job_type = updated_job.type
         job_type_name = 'Unknown'
-        if 'novostoic' in job_type:
+        if 'oed-' in job_type:
+            openenzymedb_frontend_url = app_config['openenzymedb_frontend_url']
+            if job_type == JobType.OED_DLKCAT:
+                results_url = f'{openenzymedb_frontend_url}/tools/dlkcat/result/{updated_job.job_id}'
+                job_type_name = 'OpenEnzymeDB DLKCat DeepLearning Approach'
+            elif job_type == JobType.OED_UNIKP:
+                results_url = f'{openenzymedb_frontend_url}/tools/unikp/result/{updated_job.job_id}'
+                job_type_name = 'OpenEnzymeDB UniKP'
+            elif job_type == JobType.OED_CATPRED:
+                results_url = f'{openenzymedb_frontend_url}/tools/catpred/result/{updated_job.job_id}'
+                job_type_name = 'OpenEnzymeDB CatPred'
+        elif 'novostoic' in job_type:
             novostoic_frontend_url = app_config['novostoic_frontend_url']
             if job_type == JobType.NOVOSTOIC_PATHWAYS:
                 results_url = f'{novostoic_frontend_url}/pathway-search/result/{updated_job.job_id}'

--- a/app/services/openenzymedb_service.py
+++ b/app/services/openenzymedb_service.py
@@ -1,0 +1,42 @@
+import json
+import os
+import time
+
+from fastapi import HTTPException
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from config import log
+from models.enums import JobStatus
+from services.minio_service import MinIOService
+from services.reactionminer_search.core import txt_eval, smi_eval, mm_eval
+
+
+class OpenEnzymeDBService:
+    def __init__(self, db) -> None:
+        self.db = db
+
+    @staticmethod
+    async def resultPostProcess(bucket_name: str, job_id: str, service: MinIOService, db: AsyncSession):
+        """
+        Outputs stored in Minio: /{job_id}/out/*  Bucket name: oed-*
+        """
+        folder_path = f"/{job_id}/out/"
+        objects = service.list_files(bucket_name, folder_path)
+
+        # Iterate over folder and add all contents to a dictionary
+        content = {}
+        for obj in objects:
+            file_name = os.path.basename(obj.object_name).split('/')[-1]
+            if file_name.endswith('.json'):
+                content[file_name] = json.loads(service.get_file(bucket_name=bucket_name, object_name=obj.object_name))
+            elif file_name.endswith('.csv'):
+                content[file_name] = service.get_file(bucket_name=bucket_name, object_name=obj.object_name)
+            else:
+                log.warning(f'Skipping unrecognized file extension: ' + str(file_name))
+
+        # Return the dictionary if it has contents
+        if not content:
+            raise HTTPException(status_code=404, detail=f"No output files were found")
+
+        return content
+

--- a/chart/values.local.yaml
+++ b/chart/values.local.yaml
@@ -22,6 +22,7 @@ controller:
   molli_frontend_url: "http://localhost:4200"
   aceretro_frontend_url: "http://localhost:4200"
   reactionminer_frontend_url: "http://localhost:4200"
+  openenzymedb_frontend_url: "http://localhost:4200"
 
 postgresql:
   enabled: true

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -101,6 +101,27 @@ config:
       - effect: NoSchedule  
         key: mmli.role  
         operator: Exists
+    oed-dlkcat-dla:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+    oed-unikp:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+    oed-catpred:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
     somn:
       nodeSelector:
         ncsa.role: worker-job
@@ -145,6 +166,7 @@ config:
   molli_frontend_url: "https://molli.platform.moleculemaker.org"
   aceretro_frontend_url: "https://aceretro.platform.moleculemaker.org"
   reactionminer_frontend_url: "https://reactionminer.platform.moleculemaker.org"
+  openenzymedb_frontend_url: "https://openenzymedb.platform.moleculemaker.org"
 
 
 postgresql:

--- a/chart/values.staging.yaml
+++ b/chart/values.staging.yaml
@@ -25,6 +25,27 @@ config:
       - effect: NoSchedule
         key: mmli.role
         operator: Exists
+    oed-dlkcat-dla:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+    oed-unikp:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+    oed-catpred:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
     novostoic-dgpredictor:
       nodeSelector:	
         ncsa.role: worker-job	
@@ -133,6 +154,7 @@ config:
   molli_frontend_url: "https://molli.frontend.staging.mmli1.ncsa.illinois.edu"
   aceretro_frontend_url: "https://aceretro.frontend.staging.mmli1.ncsa.illinois.edu"
   reactionminer_frontend_url: "https://reactionminer.frontend.staging.mmli1.ncsa.illinois.edu"
+  openenzymedb_frontend_url: "https://frontend.staging.openenzymedb.mmli1.ncsa.illinois.edu"
 
 postgresql:
   enabled: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -238,7 +238,7 @@ config:
           claimName: 'mmli-clean-job-weights'
         - mountPath: /data
           name: shared-storage
-          subPath: uws/jobs/oed-unikp/.pretrained
+          subPath: uws/jobs/oed-catpred/.pretrained
           claimName: 'mmli-clean-job-weights'
 
     # Config for running ReactionMiner job

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -236,9 +236,13 @@ config:
           mountPath: '/uws/jobs/oed-catpred/JOB_ID/out'
           subPath: 'uws/jobs/oed-catpred/JOB_ID/out'
           claimName: 'mmli-clean-job-weights'
-        - mountPath: /data
+        - mountPath: /catpred_pipeline/data
           name: shared-storage
           subPath: uws/jobs/oed-catpred/.pretrained
+          claimName: 'mmli-clean-job-weights'
+        - mountPath: /catpred_pipeline/catpred/production_models
+          name: shared-storage
+          subPath: uws/jobs/oed-catpred/.pretrained/pretrained/production
           claimName: 'mmli-clean-job-weights'
 
     # Config for running ReactionMiner job

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -70,6 +70,7 @@ config:
   clean_frontend_url: "https://clean.frontend.staging.mmli1.ncsa.illinois.edu"
   molli_frontend_url: "https://molli.frontend.staging.mmli1.ncsa.illinois.edu"
   aceretro_frontend_url: "https://aceretro.frontend.staging.mmli1.ncsa.illinois.edu"
+  openenzymedb_frontend_url: "https://frontend.staging.openenzymedb.mmli1.ncsa.illinois.edu"
 
   server:
     port: 8080
@@ -172,6 +173,18 @@ config:
           mountPath: '/root/.cache/torch/hub/checkpoints'
           subPath: 'weights'
           claimName: 'mmli-clean-job-weights'
+
+
+    # Config for running OpenEnzymeDB job(s)
+    oed-dlkcat:
+      image: 'moleculemaker/oed-dlkcat-dla'
+      imagePullPolicy: 'Always'
+    oed-unikp:
+      image: 'moleculemaker/oed-unikp'
+      imagePullPolicy: 'Always'
+    oed-catpred:
+      image: 'moleculemaker/oed-catpred'
+      imagePullPolicy: 'Always'
 
     # Config for running ReactionMiner job
     reactionminer:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -236,6 +236,10 @@ config:
           mountPath: '/uws/jobs/oed-catpred/JOB_ID/out'
           subPath: 'uws/jobs/oed-catpred/JOB_ID/out'
           claimName: 'mmli-clean-job-weights'
+        - mountPath: /data
+          name: shared-storage
+          subPath: uws/jobs/oed-unikp/.pretrained
+          claimName: 'mmli-clean-job-weights'
 
     # Config for running ReactionMiner job
     reactionminer:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -194,6 +194,12 @@ config:
       image: 'moleculemaker/oed-unikp'
       imagePullPolicy: 'Always'
       volumes:
+        - mountPath: /root/.cache/huggingface/hub
+          name: shared-storage
+          subPath: uws/jobs/oed-unikp/.cache
+        - mountPath: /usr/app/UniKP
+          name: shared-storage
+          subPath: uws/jobs/oed-unikp/.models
         - name: 'shared-storage'
           mountPath: '/uws/jobs/oed-unikp/JOB_ID/in'
           subPath: 'uws/jobs/oed-unikp/JOB_ID/in'
@@ -202,6 +208,17 @@ config:
           mountPath: '/uws/jobs/oed-unikp/JOB_ID/out'
           subPath: 'uws/jobs/oed-unikp/JOB_ID/out'
           claimName: 'mmli-clean-job-weights'
+      secrets:
+        - mountPath: '/root/.cache/token'
+          name: 'token'
+          subPath: 'token'
+          readOnly: 'true'
+          secretName: huggingface-token
+          # "itemList" takes the place of "items"
+          # This should avoid overlap with the built-in items() function
+          itemList:
+            - key: token
+              path: token
 
 
     # Config for running OpenEnzymeDB CatPred job

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -175,16 +175,48 @@ config:
           claimName: 'mmli-clean-job-weights'
 
 
-    # Config for running OpenEnzymeDB job(s)
+    # Config for running OpenEnzymeDB DLKcat job
     oed-dlkcat:
       image: 'moleculemaker/oed-dlkcat-dla'
       imagePullPolicy: 'Always'
+      volumes:
+        - name: 'shared-storage'
+          mountPath: '/uws/jobs/oed-dlkcat/JOB_ID/in'
+          subPath: 'uws/jobs/oed-dlkcat/JOB_ID/in'
+          claimName: 'mmli-clean-job-weights'
+        - name: 'shared-storage'
+          mountPath: '/uws/jobs/oed-dlkcat/JOB_ID/out'
+          subPath: 'uws/jobs/oed-dlkcat/JOB_ID/out'
+          claimName: 'mmli-clean-job-weights'
+
+    # Config for running OpenEnzymeDB UniKP job
     oed-unikp:
       image: 'moleculemaker/oed-unikp'
       imagePullPolicy: 'Always'
+      volumes:
+        - name: 'shared-storage'
+          mountPath: '/uws/jobs/oed-unikp/JOB_ID/in'
+          subPath: 'uws/jobs/oed-unikp/JOB_ID/in'
+          claimName: 'mmli-clean-job-weights'
+        - name: 'shared-storage'
+          mountPath: '/uws/jobs/oed-unikp/JOB_ID/out'
+          subPath: 'uws/jobs/oed-unikp/JOB_ID/out'
+          claimName: 'mmli-clean-job-weights'
+
+
+    # Config for running OpenEnzymeDB CatPred job
     oed-catpred:
       image: 'moleculemaker/oed-catpred'
       imagePullPolicy: 'Always'
+      volumes:
+        - name: 'shared-storage'
+          mountPath: '/uws/jobs/oed-catpred/JOB_ID/in'
+          subPath: 'uws/jobs/oed-catpred/JOB_ID/in'
+          claimName: 'mmli-clean-job-weights'
+        - name: 'shared-storage'
+          mountPath: '/uws/jobs/oed-catpred/JOB_ID/out'
+          subPath: 'uws/jobs/oed-catpred/JOB_ID/out'
+          claimName: 'mmli-clean-job-weights'
 
     # Config for running ReactionMiner job
     reactionminer:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -197,9 +197,11 @@ config:
         - mountPath: /root/.cache/huggingface/hub
           name: shared-storage
           subPath: uws/jobs/oed-unikp/.cache
+          claimName: 'mmli-clean-job-weights'
         - mountPath: /usr/app/UniKP
           name: shared-storage
           subPath: uws/jobs/oed-unikp/.models
+          claimName: 'mmli-clean-job-weights'
         - name: 'shared-storage'
           mountPath: '/uws/jobs/oed-unikp/JOB_ID/in'
           subPath: 'uws/jobs/oed-unikp/JOB_ID/in'


### PR DESCRIPTION
RECREATED FROM #85 DUE TO UNAVOIDABLE OUTAGE ON GITHUB

## Problem
We need a way to programmatically run the three new OpenEnzymeDB tools: DLKcat, UniKP, CatPred

Related to https://github.com/moleculemaker/OpenEnzymeDB-frontend/issues/33 

## Approach
* feat: create a simple JobType for the 3 new OED tools

TODOs:
* decide how to handle email notifications - send 3 emails? only send 1 email? send no emails?


## How to Test
Currently deployed on `mmli-backend-staging`

1. Navigate to https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu/docs#/Jobs/create_job__job_type__jobs_post
2. Click "Try It Out" and edit the request body to match the following:
```
{
  "job_id": "apitest",
  "email": "lambert8@illinois.edu",
  "job_info": "{\"input_pairs\":[{\"name\":\"example\",\"smiles\":\"OC1=CC=C(C[C@@H](C(O)=O)N)C=C1\",\"sequence\":\"MEDIPDTSRPPLKYVKGIPLIKYFAEALESLQDFQAQPDDLLISTYPKSGTTWVSEILDMIYQDGDVEKCRRAPVFIRVPFLEFKAPGIPTGLEVLKDTPAPRLIKTHLPLALLPQTLLDQKVKVVYVARNAKDVAVSYYHFYRMAKVHPDPDTWDSFLEKFMAGEVSYGSWYQHVQEWWELSHTHPVLYLFYEDMKENPKREIQKILKFVGRSLPEETVDLIVQHTSFKEMKNNSMANYTTLSPDIMDHSISAFMRKGISGDWKTTFTVAQNERFDADYAKKMEGCGLSFRTQL\"}]}"
}
```
3. Set job_type = `oed-catpred`, and click "Execute" to submit the job - note that `job_id` must be unique (in the past 24h) per-job-type or the job will not be created on the cluster
    * Check MinIO for output file once the job has completed: `oed-catpred/apitest/out/catpred-output.json`
```json
[
    {
        "substrate": "example",
        "sequence": "MEDIPDTSRPPLKYVKGIPLIKYFAEALESLQDFQAQPDDLLISTYPKSGTTWVSEILDMIYQDGDVEKCRRAPVFIRVPFLEFKAPGIPTGLEVLKDTPAPRLIKTHLPLALLPQTLLDQKVKVVYVARNAKDVAVSYYHFYRMAKVHPDPDTWDSFLEKFMAGEVSYGSWYQHVQEWWELSHTHPVLYLFYEDMKENPKREIQKILKFVGRSLPEETVDLIVQHTSFKEMKNNSMANYTTLSPDIMDHSISAFMRKGISGDWKTTFTVAQNERFDADYAKKMEGCGLSFRTQL",
        "smiles": "N[C@@H](Cc1ccc(O)cc1)C(=O)O",
        "kcat": "2.43876647199056",
        "km": "0.1364418548322705",
        "ki": "0.32666428163545397"
    }
]
```