### PR TITLE
added endpoint to canonicalize SMILES

### DIFF
--- a/app/routers/shared.py
+++ b/app/routers/shared.py
@@ -1,17 +1,18 @@
 from typing import Annotated
 from fastapi import APIRouter, HTTPException, Query
 from services.shared import draw_chemical_svg
+from services.rdkit_service import RDKitService
 
 router = APIRouter()
 
 @router.get("/smiles/draw", tags=['Shared'])
 async def draw_smiles(
-    smiles: str, 
+    smiles: str,
     highlightAtoms: Annotated[list[int] | None, Query()] = Query(default=None)
 ):
-    if type(smiles) != str: 
+    if type(smiles) != str:
         raise HTTPException(status_code=400, detail=f"Input must be a single SMILES string. Got type: `{type(smiles)}` with SMILES = `{smiles}`")
-    
+
     try:
         return draw_chemical_svg(smiles, highlightAtoms=highlightAtoms)
     except Exception as e:
@@ -21,3 +22,16 @@ async def draw_smiles(
 # @router.get("/chemicals/info", tags=['Shared'])
 # async def get_chemical_info(ids: list[str]):
     # return None
+
+@router.get("/smiles/canonicalize", tags=['Shared'])
+async def canonicalize_smiles(
+    smiles: str
+):
+    if type(smiles) != str:
+        raise HTTPException(status_code=400, detail=f"Input must be a single SMILES string. Got type: `{type(smiles)}` with SMILES = `{smiles}`")
+
+    try:
+        return RDKitService().canonicalize_smiles(smiles)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+

--- a/app/services/rdkit_service.py
+++ b/app/services/rdkit_service.py
@@ -38,3 +38,10 @@ class RDKitService:
         bitVect2 = DataStructs.CreateFromBitString(bitString2)
         similarity = DataStructs.TanimotoSimilarity(bitVect1, bitVect2)
         return similarity
+
+    def canonicalize_smiles(self, smiles):
+        mol = Chem.MolFromSmiles(smiles)
+        if mol:
+            return Chem.MolToSmiles(mol, canonical=True)
+        else:
+            return None


### PR DESCRIPTION
Added an endpoint that, given a SMILES string, returns a canonicalized SMILES string using RDKit. There are other APIs that offer similar functionality, but for OED, we particularly need one that uses RDKit's method so we can match user input to SMILES in the data.