### PR TITLE
feat: add ez-specificity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from Python 3.10 in the /code directory
-FROM --platform=linux/amd64 condaforge/mambaforge:24.1.2-0
+FROM condaforge/mambaforge:24.1.2-0
 WORKDIR /code
 
 # Set noninteractive installation and timezone
@@ -9,6 +9,7 @@ ENV TZ=Etc/UTC
 # Install build dependencies and OpenJDK
 RUN apt-get update && apt-get install -y \
     build-essential \
+    curl \
     gcc \
     zlib1g-dev \
     openjdk-11-jdk \

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -71,6 +71,9 @@ kubernetes_jobs:
   chemscraper:
     image: moleculemaker/chemscraper-job:latest
     imagePullPolicy: Always
+    initContainers:
+      - image: minio/mc
+        command: '' # check if file exists in bucket
     env:
       - name: LOG_LEVEL
         value: DEBUG
@@ -381,41 +384,60 @@ kubernetes_jobs:
     # TODO: probably could adjust resource limits here
     resources:
       limits:
-        cpu: "64"
-        memory: "24Gi"
+        cpu: "8"
+        memory: "8Gi"
       requests:
-        cpu: "16"
-        memory: "12Gi"
+        cpu: "4"
+        memory: "4Gi"
 
   # TODO: update to use correct image later
-  ez-specificity:
-    # Kubeconfig (credentials + cluster) used to run this job in Kubernetes
-    kubeconfig: "/opt/kubeconfig"
-    # Namespace where this job should run
-    namespace: "mmli"
-
+  test1:
     # Example job image name + command combo
-    image: "perl:5.34.0"
-    command: "perl -Mbignum=bpi -wle 'print bpi(2000)' > ${JOB_OUTPUT_DIR}/pi.out"
+    image: "ubuntu:jammy"
+    command: "echo '1' > ${JOB_OUTPUT_DIR}/step1.out"
 
-    ## Server working directory to store generated job data
-    workingVolume:
-      claimName: "mmli-shared-job-data"
-      mountPath: "/uws"
-      subPath: "uws"
-    ## Central data volumes to be mounted in job containers
-    volumes: []
+  # TODO: update to use correct image later
+  test2:
+    # Example job image name + command combo
+    image: "ubuntu:jammy"
+    command: "echo $(($(cat /uws/jobs/test1/${JOB_ID}/out/step1.out) * 5)) > ${JOB_OUTPUT_DIR}/step2.out"
+    initContainers:
+      - name: wait-for-test1
+        image: minio/mc
+        command: [ "/bin/bash", "-c" ]
+        env:
+          - name: MINIO_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: mmli-backend-secrets
+                key: MINIO_ACCESS_KEY
+          - name: MINIO_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: mmli-backend-secrets
+                key: MINIO_SECRET_KEY
+        args:
+          - |
+            set -x
+            set -e
+            export SLEEP_DELAY=30
+            export MINIO_FILE_PATH=test1/${JOB_ID}/out/step1.out;
+            
+            # Loop until 'mc ls' finds the file (returns exit code 0)
+            mc alias set mmli2 http://${MINIO_SERVER} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY};
+            echo "Waiting for ${MINIO_FILE_PATH}...";
+            until mc ls "mmli2/$MINIO_FILE_PATH" 2>&1; do
+              echo "File not found. Retrying in ${SLEEP_DELAY} seconds...";
+              sleep ${SLEEP_DELAY};
+            done;
 
-    ## Abort jobs after 3 days regardless of their behavior
-    activeDeadlineSeconds: 259200
-    ## Cleanup completed/failed jobs after 12 hours
-    ttlSecondsAfterFinished: 43200
-    ## Poll the log file for changes every `logFilePollingPeriod` seconds
-    logFilePollingPeriod: 300
-    securityContext:
-      runAsUser: 0
-      runAsGroup: 0
-      # fsGroup: 202
+            echo "File detected! Preparing inputs...";
+            # TODO: Download files needed for next steps
+            # TODO: Validation / filtering / mapping to valid inputs
+
+            echo "Inputs ready: Init container completed successful!";
+            exit 0
+
 
 external:
   chemscraper:

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -10,7 +10,7 @@ server:
   hostName: "mmli.fastapi.mmli2.ncsa.illinois.edu"
 
 minio:
-  server: "minio:9000"
+  server: "mmli-backend-minio.mmli.svc.cluster.local:9000"
   apiBaseUrl: "minioapi.mmli.fastapi.localhost"
 
 auth:
@@ -25,6 +25,7 @@ email:
 # Change frontend service URLs depending on where they're deployed (used for email notifications)
 chemscraper_url: "http://chemscraper-services-staging.staging.svc.cluster.local:8000"
 chemscraper_frontend_url: "https://chemscraper.frontend.staging.mmli2.ncsa.illinois.edu"
+ezspecificity_frontend_url: "https://ezspecificity.frontend.staging.mmli2.ncsa.illinois.edu"
 novostoic_frontend_url: "https://novostoic.frontend.staging.mmli2.ncsa.illinois.edu"
 somn_frontend_url: "https://somn.frontend.staging.mmli2.ncsa.illinois.edu"
 clean_frontend_url: "https://clean.frontend.staging.mmli2.ncsa.illinois.edu"
@@ -424,53 +425,71 @@ kubernetes_jobs:
         cpu: "4"
         memory: "4Gi"
 
+  ez-specificity:
+    # Example job image name + command combo
+    image: "moleculemaker/mmli-backend:coord-jobs"
+    command: "python ./coordinator.py"
+    steps:
+      # Define names / order for steps here
+      - ezspec-unidock
+      - ezspec-inference
+    resources:
+      limits:
+        cpu: "2"
+        memory: "2Gi"
+      requests:
+        cpu: "1"
+        memory: "1Gi"
+
   # TODO: update to use correct image later
-  test1:
+  ezspec-unidock:
     # Example job image name + command combo
     image: "ubuntu:jammy"
-    command: "echo '1' > ${JOB_OUTPUT_DIR}/step1.out"
+    command: "echo 5 > ${JOB_OUTPUT_DIR}/step1.out"
 
   # TODO: update to use correct image later
-  test2:
+  ezspec-inference:
     # Example job image name + command combo
     image: "ubuntu:jammy"
-    command: "echo $(($(cat /uws/jobs/test1/${JOB_ID}/out/step1.out) * 5)) > ${JOB_OUTPUT_DIR}/step2.out"
-    initContainers:
-      - name: wait-for-test1
-        image: minio/mc
-        command: [ "/bin/bash", "-c" ]
-        env:
-          - name: MINIO_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: mmli-backend-secrets
-                key: MINIO_ACCESS_KEY
-          - name: MINIO_SECRET_KEY
-            valueFrom:
-              secretKeyRef:
-                name: mmli-backend-secrets
-                key: MINIO_SECRET_KEY
-        args:
-          - |
-            set -x
-            set -e
-            export SLEEP_DELAY=30
-            export MINIO_FILE_PATH=test1/${JOB_ID}/out/step1.out;
-            
-            # Loop until 'mc ls' finds the file (returns exit code 0)
-            mc alias set mmli2 http://${MINIO_SERVER} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY};
-            echo "Waiting for ${MINIO_FILE_PATH}...";
-            until mc ls "mmli2/$MINIO_FILE_PATH" 2>&1; do
-              echo "File not found. Retrying in ${SLEEP_DELAY} seconds...";
-              sleep ${SLEEP_DELAY};
-            done;
+    command: "echo 10 > ${JOB_OUTPUT_DIR}/step2.out"
 
-            echo "File detected! Preparing inputs...";
-            # TODO: Download files needed for next steps
-            # TODO: Validation / filtering / mapping to valid inputs
-
-            echo "Inputs ready: Init container completed successful!";
-            exit 0
+        # XXX: this is a new feature, but we're not sure if it will stick around yet
+#        initContainers:
+#          - name: wait-for-test1
+#            image: minio/mc
+#            command: [ "/bin/bash", "-c" ]
+#            env:
+#              - name: MINIO_ACCESS_KEY
+#                valueFrom:
+#                  secretKeyRef:
+#                    name: mmli-backend-secrets
+#                    key: MINIO_ACCESS_KEY
+#              - name: MINIO_SECRET_KEY
+#                valueFrom:
+#                  secretKeyRef:
+#                    name: mmli-backend-secrets
+#                    key: MINIO_SECRET_KEY
+#            args:
+#              - |
+#                set -x
+#                set -e
+#                export SLEEP_DELAY=30
+#                export MINIO_FILE_PATH=test1/${JOB_ID}/out/step1.out;
+#
+#                # Loop until 'mc ls' finds the file (returns exit code 0)
+#                mc alias set mmli2 http://${MINIO_SERVER} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY};
+#                echo "Waiting for ${MINIO_FILE_PATH}...";
+#                until mc ls "mmli2/$MINIO_FILE_PATH" 2>&1; do
+#                  echo "File not found. Retrying in ${SLEEP_DELAY} seconds...";
+#                  sleep ${SLEEP_DELAY};
+#                done;
+#
+#                echo "File detected! Preparing inputs...";
+#                # TODO: Download files needed for next steps
+#                # TODO: Validation / filtering / mapping to valid inputs
+#
+#                echo "Inputs ready: Init container completed successful!";
+#                exit 0
 
 
 external:

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -71,9 +71,6 @@ kubernetes_jobs:
   chemscraper:
     image: moleculemaker/chemscraper-job:latest
     imagePullPolicy: Always
-    initContainers:
-      - image: minio/mc
-        command: '' # check if file exists in bucket
     env:
       - name: LOG_LEVEL
         value: DEBUG

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -10,7 +10,7 @@ server:
   hostName: "mmli.fastapi.mmli2.ncsa.illinois.edu"
 
 minio:
-  server: "mmli-backend-minio.mmli.svc.cluster.local:9000"
+  server: "minio:9000"
   apiBaseUrl: "minioapi.mmli.fastapi.localhost"
 
 auth:

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -430,6 +430,8 @@ kubernetes_jobs:
       # Define names / order for steps here
       - ezspec-unidock
       - ezspec-inference
+
+    # Parent job doesn't need many resources
     resources:
       limits:
         cpu: "2"
@@ -438,17 +440,46 @@ kubernetes_jobs:
         cpu: "1"
         memory: "1Gi"
 
-  # TODO: update to use correct image later
-  ezspec-unidock:
-    # Example job image name + command combo
-    image: "ubuntu:jammy"
-    command: "echo 5 > ${JOB_OUTPUT_DIR}/step1.out"
 
-  # TODO: update to use correct image later
+  ezspec-unidock:
+    image: moleculemaker/ezspec-unidock:latest
+    imagePullPolicy: Always
+    #command: "echo 5 > ${JOB_OUTPUT_DIR}/step1.out"
+    env:
+      - name: NVIDIA_DRIVER_CAPABILITIES
+        value: compute,utility
+      - name: NVIDIA_VISIBLE_DEVICES
+        value: all
+    volumes:
+      - name: shared-storage
+        mountPath: /uws/jobs/ezspec-unidock/JOB_ID/in
+        subPath: uws/jobs/ezspec-unidock/JOB_ID/in
+        claimName: mmli-shared-job-data
+      - name: shared-storage
+        mountPath: /uws/jobs/ezspec-unidock/JOB_ID/out
+        subPath: uws/jobs/ezspec-unidock/JOB_ID/out
+        claimName: mmli-shared-job-data
+
+
   ezspec-inference:
-    # Example job image name + command combo
-    image: "ubuntu:jammy"
-    command: "echo 10 > ${JOB_OUTPUT_DIR}/step2.out"
+    image: moleculemaker/ezspec-inference:latest
+    imagePullPolicy: Always
+    #command: "echo 10 > ${JOB_OUTPUT_DIR}/step2.out"
+    env:
+      - name: NVIDIA_DRIVER_CAPABILITIES
+        value: compute,utility
+      - name: NVIDIA_VISIBLE_DEVICES
+        value: all
+    volumes:
+      - name: shared-storage
+        mountPath: /uws/jobs/ezspec-inference/JOB_ID/in
+        subPath: uws/jobs/ezspec-inference/JOB_ID/in
+        claimName: mmli-shared-job-data
+      - name: shared-storage
+        mountPath: /uws/jobs/ezspec-inference/JOB_ID/out
+        subPath: uws/jobs/ezspec-inference/JOB_ID/out
+        claimName: mmli-shared-job-data
+
 
         # XXX: this is a new feature, but we're not sure if it will stick around yet
 #        initContainers:

--- a/app/cfg/config.yaml
+++ b/app/cfg/config.yaml
@@ -424,7 +424,7 @@ kubernetes_jobs:
 
   ez-specificity:
     # Example job image name + command combo
-    image: "moleculemaker/mmli-backend:coord-jobs"
+    image: "moleculemaker/mmli-backend:latest"
     command: "python ./coordinator.py"
     steps:
       # Define names / order for steps here

--- a/app/config.py
+++ b/app/config.py
@@ -5,6 +5,8 @@ import yaml
 from collections import ChainMap
 from dotenv import load_dotenv
 
+from models.enums import JobTypes
+
 
 def get_logger(name):
     logger = logging.getLogger(name)
@@ -46,6 +48,7 @@ with open(CONFIG_FILEPATH, "r") as server_yaml_file:
     except Exception as ex:
         log.error(f'Failed to load secrets file: {ex}')
 
+log.info('Valid job types : ', JobTypes)
 log.info('Server configuration: ', app_config)
 
 # Override app_config with some individual environment variables

--- a/app/config.py
+++ b/app/config.py
@@ -48,8 +48,8 @@ with open(CONFIG_FILEPATH, "r") as server_yaml_file:
     except Exception as ex:
         log.error(f'Failed to load secrets file: {ex}')
 
-log.info('Valid job types : ', JobTypes)
-log.info('Server configuration: ', app_config)
+log.info(f'Valid job types : {str(JobTypes)}')
+log.info(f'Server configuration: {str(app_config)}', )
 
 # Override app_config with some individual environment variables
 # TODO: Is this needed??

--- a/app/coordinator.py
+++ b/app/coordinator.py
@@ -125,7 +125,6 @@ try:
 
         # Upload our local scratch directory to MinIO for processing
         upload_local_directory_to_minio(
-            minio_server=minio_server,
             local_path=scratch_dir,
             bucket_name=subjob_type,
             minio_prefix=f'{subjob_id}/in'
@@ -172,7 +171,6 @@ try:
         # Output files should now be present in MinIO: e.g. bucket=step  path={job_id}/out
         # Download them to our local scratch directory
         download_remote_directory_from_minio(
-            minio_server=minio_server,
             remote_path=f'{subjob_id}/out',
             bucket_name=subjob_type,
             target_directory=scratch_dir

--- a/app/coordinator.py
+++ b/app/coordinator.py
@@ -7,7 +7,6 @@ import traceback
 from time import sleep
 
 import requests
-from fastapi import HTTPException
 from requests import Response
 
 from config import get_logger, app_config
@@ -24,7 +23,8 @@ target_directory = os.sep.join(job_input_dir.split(os.sep)[0:-2])
 
 remote_path = os.path.join(job_id, 'in')
 
-hostname = os.getenv('MMLI_BACKEND_HOST')
+mmli_hostname = os.getenv('MMLI_BACKEND_HOST')
+minio_server = os.getenv('MINIO_SERVER')
 
 log = get_logger(__name__)
 
@@ -39,7 +39,7 @@ def create_job_step(step_type: str, subjob_id: str, job_config=None) -> str:
 
     # Create a subjob that will run this step on the input files
     resp: Response = requests.post(
-        f'{hostname}/{step_type}/jobs',
+        f'{mmli_hostname}/{step_type}/jobs',
         data=json.dumps(req_body),
         headers={
             "Content-Type": "application/json",
@@ -66,7 +66,7 @@ def create_job_step(step_type: str, subjob_id: str, job_config=None) -> str:
 
 
 def get_job_step_status(step_name: str, step_id: str) -> str:
-    resp = requests.get(f'{hostname}/{step_name}/jobs/{step_id}')
+    resp = requests.get(f'{mmli_hostname}/{step_name}/jobs/{step_id}')
     resp.raise_for_status()
     job_list = resp.json()
     log.debug(f'job_type={job_type}  job_id={job_id}  step_type={step_name}  step_id={step_id}  |  job_list={str(job_list)}')
@@ -125,6 +125,7 @@ try:
 
         # Upload our local scratch directory to MinIO for processing
         upload_local_directory_to_minio(
+            minio_server=minio_server,
             local_path=scratch_dir,
             bucket_name=subjob_type,
             minio_prefix=f'{subjob_id}/in'
@@ -171,6 +172,7 @@ try:
         # Output files should now be present in MinIO: e.g. bucket=step  path={job_id}/out
         # Download them to our local scratch directory
         download_remote_directory_from_minio(
+            minio_server=minio_server,
             remote_path=f'{subjob_id}/out',
             bucket_name=subjob_type,
             target_directory=scratch_dir

--- a/app/coordinator.py
+++ b/app/coordinator.py
@@ -1,0 +1,201 @@
+#!/bin/env python3
+import json
+import os
+import shutil
+import sys
+import traceback
+from time import sleep
+
+import requests
+from fastapi import HTTPException
+from requests import Response
+
+from config import get_logger, app_config
+from services import kubejob_service
+from services.kubejob_service import download_remote_directory_from_minio, upload_local_directory_to_minio, \
+    api_batch_v1, get_job_name_from_id
+
+job_type = bucket_name = os.getenv('JOB_TYPE')
+job_id = os.getenv('JOB_ID')
+
+job_input_dir = os.getenv('JOB_INPUT_DIR')
+job_output_dir = os.getenv('JOB_OUTPUT_DIR')
+namespace = os.getenv('NAMESPACE')
+target_directory = os.sep.join(job_input_dir.split(os.sep)[0:-2])
+
+remote_path = os.path.join(job_id, 'in')
+
+hostname = os.getenv('MMLI_BACKEND_HOST', 'http://mmli-backend.mmli.svc.cluster.local:8080')
+
+log = get_logger(__name__)
+
+
+def create_job_step(step_type: str, subjob_id: str, job_config=None) -> str:
+    req_body = {
+        "job_id": subjob_id,
+        # "run_id": step_type,
+        # "email": "",
+        "job_info": json.dumps(job_config)   # Any additional JSON inputs?
+    } if job_config is not None else { "job_id": subjob_id }
+
+    # Create a subjob that will run this step on the input files
+    resp: Response = requests.post(
+        f'{hostname}/{step_type}/jobs',
+        data=json.dumps(req_body),
+        headers={
+            "Content-Type": "application/json",
+        }
+    )
+
+    # Ensure that job was submitted successfully
+    try:
+        resp.raise_for_status()
+        if resp.status_code == 200 or resp.status_code == 201:
+            job_status = resp.json()
+            step_id = job_status['job_id']
+
+            log.debug(
+                f'job_type={job_type}  job_id={job_id}  step_type={step_type}  step_id={subjob_id}  |  Job step created! status={str(job_status)}')
+            log.info(f'job_type={job_type}  job_id={job_id}  step_type={step_type}  step_id={subjob_id}  |  Waiting for step to be completed...')
+
+            # Return job_id / step_id
+            return step_id
+    except Exception as e:
+        log.error(f'job_type={job_type}  job_id={job_id}  step={step_type}  step_id={subjob_id}  |  Failed to get status for step: {str(e)}')
+        log.error(traceback.format_exc())
+        sys.exit(resp.status_code)
+
+
+def get_job_step_status(step_name: str, step_id: str) -> str:
+    resp = requests.get(f'{hostname}/{step_name}/jobs/{step_id}')
+    resp.raise_for_status()
+    job_list = resp.json()
+    log.debug(f'job_type={job_type}  job_id={job_id}  step_type={step_name}  step_id={step_id}  |  job_list={str(job_list)}')
+    job_status = job_list[0] if len(job_list) > 0 else None
+    log.debug(f'job_type={job_type}  job_id={job_id}  step={step_name}  step_id={step_id}  |  job_status={str(job_status)}')
+    return job_status
+
+
+try:
+    scratch_dir = job_output_dir
+    log.info(f'job_type={job_type}  job_id={job_id}  |  Running and coordinating job steps...')
+    log.debug(f'job_type={job_type}  job_id={job_id}  |     job_input_dir={job_input_dir}')
+    log.debug(f'job_type={job_type}  job_id={job_id}  |     job_output_dir={job_output_dir}')
+    log.debug(f'job_type={job_type}  job_id={job_id}  |     scratch_dir={scratch_dir}')
+
+    # See cfg/config.yaml (defaults) and chart/values.yaml (per-environment configs)
+    job_defn = app_config['kubernetes_jobs'][job_type]
+    keys = job_defn['steps'] if 'steps' in job_defn else None   # ['ezspec-docking', 'ezspec-inference']
+
+    if keys is None:
+        log.error(f'Failed to coordinate job_type={job_type}: unsupported job_type')
+        sys.exit(-400)
+    if len(keys) == 0:
+        log.error(f'Failed to coordinate job_type={job_type}: job_type has no steps defined')
+        sys.exit(-500)
+
+    ezspec_unidock_job_id = os.getenv('EZSPEC_UNIDOCK_JOB_ID')
+    ezspec_inference_job_id = os.getenv('EZSPEC_INFERENCE_JOB_ID')
+    steps = dict(zip(keys, [
+        ezspec_unidock_job_id,
+        ezspec_inference_job_id
+    ]))
+
+    log.info(f'job_type={job_type}  job_id={job_id}  |  Running job steps: {str(steps)}')
+
+    # To cut down on minio spam / size, we could do all of these as local "copy" from the NFS
+    # But this would make the prejob/postjob unnecessary for these steps, and that's currently not optional
+    # So we may want to weigh or options before investing too heavily in one solution or the other
+    # This may seem wasteful, but should work for now and provide us with accounting/logging if stuff goes wrong
+
+    # Our prejob should have already downloaded user inputs to job_input_dir
+    # Copy these to our scratch folder, which is passed along to all subjobs
+    shutil.copytree(job_input_dir, scratch_dir, dirs_exist_ok=True)
+
+    # All subjobs can use the same job_info/job_config as the parent job
+    job_config = {
+        "parent_job_id": job_id,
+        "ezspec_unidock_job_id": ezspec_unidock_job_id,
+        "ezspec_inference_job_id": ezspec_inference_job_id,
+    }
+
+    # Our steps (subjobs) are now ready to run!
+
+    for subjob_type, subjob_id in steps.items():
+        log.info(f'job_type={job_type}  job_id={job_id}  step={subjob_type}  step_id={subjob_id}  |  Running job step: {subjob_id}')
+
+        # Upload our local scratch directory to MinIO for processing
+        upload_local_directory_to_minio(
+            local_path=scratch_dir,
+            bucket_name=subjob_type,
+            minio_prefix=f'{subjob_id}/in'
+        )
+
+        # Create our Job step
+        step_id = create_job_step(step_type=subjob_type, subjob_id=subjob_id, job_config=job_config)
+        if step_id is None:
+            log.error(f'job_type={job_type}  job_id={job_id}  step={subjob_type}  step_id={subjob_id}  |  FATAL: step_id=None. Aborting...')
+            log.error(traceback.format_exc())
+            sys.exit(-600)
+
+        if subjob_id != step_id:
+            log.error(
+                f'job_type={job_type}  job_id={job_id}  step={subjob_type}  step_id={subjob_id}  |  ERROR: Step / SubJob ID mismatch: {str(e)}')
+            log.error(traceback.format_exc())
+            sys.exit(-700)
+
+        # Wait for job status to be Completed
+        try:
+            log.debug(f'Polling for job status to be "completed"...')
+            job_status = get_job_step_status(step_name=subjob_type, step_id=step_id)
+            while job_status['phase'] != 'completed' and job_status['phase'] != 'error':
+                job_status = get_job_step_status(step_name=subjob_type, step_id=step_id)
+                log.debug(f'Waiting 10 seconds before polling again...')
+                sleep(10)
+        except Exception as e:
+            log.error(f'job_type={job_type}  job_id={job_id}  step={subjob_type}  step_id={subjob_id}  |  Failed to get status for step: {str(e)}')
+            log.error(traceback.format_exc())
+            sys.exit(-400)
+
+        # Ensure no error in job execution
+        if job_status['phase'] == 'error':
+            log.error(f'job_type={job_type}  job_id={job_id}  step={subjob_type}  step_id={subjob_id}  |  Job step failed with error: {str(job_status)}')
+            api_response = api_batch_v1.read_namespaced_job(
+                namespace=namespace,
+                name=get_job_name_from_id(job_type=job_type, job_id=subjob_id),
+            )
+            sys.exit(api_response['status'])
+
+        log.info(f'job_type={job_type}  job_id={job_id}  step={subjob_type}  step_id={subjob_id}  |  Job step completed successfully!')
+        log.info(f'job_type={job_type}  job_id={job_id}  step={subjob_type}  step_id={subjob_id}  |  Collecting step outputs...')
+
+        # Output files should now be present in MinIO: e.g. bucket=step  path={job_id}/out
+        # Download them to our local scratch directory
+        download_remote_directory_from_minio(
+            remote_path=f'{subjob_id}/out',
+            bucket_name=subjob_type,
+            target_directory=scratch_dir
+        )
+
+        log.info(f'job_type={job_type}  job_id={job_id}  step={subjob_type}  step_id={subjob_id}  |  Job step finished!')
+        continue
+
+    # All per-step output files should now be present in our local scratch directory + MinIO
+    # upload_local_directory_to_minio(
+    #     local_path=target_directory,
+    #     bucket_name=job_type,
+    #     minio_prefix=f'{job_id}/out',
+    # )
+    # If this is too noisy, we can copy only those output files that the frontend needs
+    # shutil.copy(f'{scratch_dir}/example.out', f'{job_output_dir}/')
+    log.info(f'job_type={job_type}  job_id={job_id}  |  All job steps completed!')
+
+    # After the job completes, our postjob should now upload all files
+    # from job_output_dir to our parent job's output folder in MinIO
+
+    sys.exit(0)
+except Exception as ex:
+    log.error(f'Failed to coordinate job_type={job_type}: job_id={job_id} - {str(ex)}')
+    traceback.print_exc()
+    sys.exit(-500)
+

--- a/app/coordinator.py
+++ b/app/coordinator.py
@@ -11,7 +11,6 @@ from fastapi import HTTPException
 from requests import Response
 
 from config import get_logger, app_config
-from services import kubejob_service
 from services.kubejob_service import download_remote_directory_from_minio, upload_local_directory_to_minio, \
     api_batch_v1, get_job_name_from_id
 
@@ -25,7 +24,7 @@ target_directory = os.sep.join(job_input_dir.split(os.sep)[0:-2])
 
 remote_path = os.path.join(job_id, 'in')
 
-hostname = os.getenv('MMLI_BACKEND_HOST', 'http://mmli-backend.mmli.svc.cluster.local:8080')
+hostname = os.getenv('MMLI_BACKEND_HOST')
 
 log = get_logger(__name__)
 

--- a/app/main.py
+++ b/app/main.py
@@ -61,6 +61,8 @@ origins = [
     "https://reactionminer.frontend.mmli1.ncsa.illinois.edu",
     "https://ezspecificity.frontend.staging.mmli1.ncsa.illinois.edu",
     "https://ezspecificity.frontend.mmli1.ncsa.illinois.edu",
+    "https://ezspecificity.frontend.staging.mmli2.ncsa.illinois.edu",
+    "https://ezspecificity.frontend.mmli2.ncsa.illinois.edu",
     # "http://another.allowed-origin.com", # Add more origins if needed
 ]
 

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -19,6 +19,9 @@ class JobType(str, Enum):
     OED_CATPRED = 'oed-catpred'
     DEFAULT = 'defaults'
     EZ_SPECIFICITY = 'ez-specificity'
+    TEST1 = 'test1'
+    TEST2 = 'test2'
+    TEST3 = 'test3'
 
     def __str__(self) -> str:
         return self.value
@@ -35,3 +38,4 @@ class JobStatus(str, Enum):
 
 
 JobTypes = [str(job_type) for job_type in JobType]
+ExampleJobTypes = ['defaults', 'test1', 'test2', 'test3']

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -19,9 +19,8 @@ class JobType(str, Enum):
     OED_CATPRED = 'oed-catpred'
     DEFAULT = 'defaults'
     EZ_SPECIFICITY = 'ez-specificity'
-    TEST1 = 'test1'
-    TEST2 = 'test2'
-    TEST3 = 'test3'
+    EZSPEC_UNIDOCK = 'ezspec-unidock'
+    EZSPEC_INFERENCE = 'ezspec-inference'
     ML_SIMPLEFOLD = 'ml-simplefold'
 
     def __str__(self) -> str:
@@ -39,4 +38,4 @@ class JobStatus(str, Enum):
 
 
 JobTypes = [str(job_type) for job_type in JobType]
-ExampleJobTypes = ['defaults', 'test1', 'test2', 'test3']
+ExampleJobTypes = [JobType.DEFAULT]

--- a/app/postjob.py
+++ b/app/postjob.py
@@ -1,7 +1,7 @@
 #!/bin/env python3
 import os
 
-from config import get_logger
+from config import get_logger, MINIO_SERVER
 from services.kubejob_service import upload_local_directory_to_minio
 
 bucket_name = os.getenv('JOB_TYPE')
@@ -13,6 +13,7 @@ log = get_logger(__name__)
 try:
     log.info(f'Uploading to MinIO: {job_output_dir}')
     upload_local_directory_to_minio(
+        minio_server=MINIO_SERVER,
         local_path=job_output_dir,
         bucket_name=bucket_name,
         minio_prefix=f"{job_id}/out")

--- a/app/postjob.py
+++ b/app/postjob.py
@@ -12,7 +12,10 @@ log = get_logger(__name__)
 
 try:
     log.info(f'Uploading to MinIO: {job_output_dir}')
-    upload_local_directory_to_minio(local_path=job_output_dir, bucket_name=bucket_name, minio_prefix=f"{job_id}/out")
+    upload_local_directory_to_minio(
+        local_path=job_output_dir,
+        bucket_name=bucket_name,
+        minio_prefix=f"{job_id}/out")
     log.info(f'Uploaded successfully to MinIO: {job_output_dir}')
 except Exception as ex:
     log.error(f'Failed to upload output files from job[{bucket_name}]: {job_id} - {str(ex)}')

--- a/app/postjob.py
+++ b/app/postjob.py
@@ -13,7 +13,6 @@ log = get_logger(__name__)
 try:
     log.info(f'Uploading to MinIO: {job_output_dir}')
     upload_local_directory_to_minio(
-        minio_server=MINIO_SERVER,
         local_path=job_output_dir,
         bucket_name=bucket_name,
         minio_prefix=f"{job_id}/out")

--- a/app/prejob.py
+++ b/app/prejob.py
@@ -1,7 +1,7 @@
 #!/bin/env python3
 import os
 
-from config import get_logger
+from config import get_logger, MINIO_SERVER
 from services.kubejob_service import download_remote_directory_from_minio
 
 bucket_name = os.getenv('JOB_TYPE')
@@ -17,6 +17,7 @@ log = get_logger(__name__)
 
 try:
     download_remote_directory_from_minio(
+        minio_server=MINIO_SERVER,
         remote_path=remote_path,
         bucket_name=bucket_name,
         target_directory=target_directory,

--- a/app/prejob.py
+++ b/app/prejob.py
@@ -1,7 +1,7 @@
 #!/bin/env python3
 import os
 
-from config import get_logger, MINIO_SERVER
+from config import get_logger
 from services.kubejob_service import download_remote_directory_from_minio
 
 bucket_name = os.getenv('JOB_TYPE')

--- a/app/prejob.py
+++ b/app/prejob.py
@@ -17,7 +17,6 @@ log = get_logger(__name__)
 
 try:
     download_remote_directory_from_minio(
-        minio_server=MINIO_SERVER,
         remote_path=remote_path,
         bucket_name=bucket_name,
         target_directory=target_directory,

--- a/app/routers/files.py
+++ b/app/routers/files.py
@@ -17,6 +17,7 @@ from models.molecule import Molecule
 from models.sqlmodel.db import get_session
 
 from models.enums import JobType
+from services.ezspecificity_service import EzSpecificityService
 from services.molli_service import MolliService
 from services.clean_service import CleanService
 
@@ -110,6 +111,18 @@ async def get_results(bucket_name: str, job_id: str, service: MinIOService = Dep
     elif bucket_name == JobType.ML_SIMPLEFOLD:
         print("Getting ML-SIMPLEFOLD job result")
         return await SimpleFoldService.resultPostProcess(bucket_name, job_id, service, db)
+
+    elif bucket_name == JobType.EZ_SPECIFICITY:
+        print("Getting EZ-SPECIFICITY job result")
+        return await EzSpecificityService.resultPostProcess(bucket_name, job_id, service, db)
+
+    elif bucket_name == JobType.EZSPEC_UNIDOCK:
+        print("Getting EZSPEC-UNIDOCK job result")
+        return await EzSpecificityService.unidockResultPostProcess(bucket_name, job_id, service, db)
+
+    elif bucket_name == JobType.EZSPEC_INFERENCE:
+        print("Getting EZSPEC-INFERENCE job result")
+        return await EzSpecificityService.inferenceResultPostProcess(bucket_name, job_id, service, db)
 
     else:
         raise HTTPException(status_code=400, detail="Invalid job type: " + bucket_name)

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -68,12 +68,17 @@ async def create_job(
         environment = []
 
         # Mount in secrets/volumes at runtime
-        volumes = []
-        secrets = []
+        #volumes = []
+        #secrets = []
 
-        if job_type == JobType.DEFAULT:
+        if job_type == JobType.DEFAULT or job_type == JobType.TEST1 or job_type == JobType.TEST2 or job_type == JobType.TEST3:
             command = app_config['kubernetes_jobs'][job_type]['command']
-            #command = f'ls -al /uws/jobs/{job_type}/{job_id}'
+            environment = app_config['kubernetes_jobs'][job_type]['env'] if 'env' in app_config['kubernetes_jobs'][job_type] else []
+            #initContainers = app_config['kubernetes_jobs'][job_type]['initContainers'] if 'initContainers' in app_config['kubernetes_jobs'][job_type] else []
+            #image = app_config['kubernetes_jobs'][job_type]['image'] if 'image' in app_config['kubernetes_jobs'][job_type] else app_config['kubernetes_jobs']['defaults']
+            #imagePullPolicy = app_config['kubernetes_jobs'][job_type]['imagePullPolicy'] if 'imagePullPolicy' in app_config['kubernetes_jobs'][job_type] else 'Always'
+            #volumes = app_config['kubernetes_jobs'][job_type]['volumes'] if 'volumes' in app_config['kubernetes_jobs'][job_type] else []
+            #secrets = app_config['kubernetes_jobs'][job_type]['secrets'] if 'secrets' in app_config['kubernetes_jobs'][job_type] else []
 
         elif job_type == JobType.CHEMSCRAPER:
             log.debug(f"Creating Kubernetes job: {job_type}")
@@ -243,14 +248,6 @@ async def create_job(
             #     # 'name': 'SOMN_PROJECT_DIR',
             #     # 'value': somn_project_dir
             # }]
-
-            # Run a Kubernetes Job with the given image + command + environment
-            try:
-                log.debug(f"Creating Kubernetes job[{job_type}]: " + job_id)
-            except Exception as ex:
-                log.error("Failed to create Job: " + str(ex))
-                raise HTTPException(status_code=400, detail="Failed to create Job: " + str(ex))
-            
         elif job_type == JobType.NOVOSTOIC_PATHWAYS:
             if service.ensure_bucket_exists(job_type):
                 job_info = json.loads(job_info.replace('\"', '"'))
@@ -312,14 +309,23 @@ async def create_job(
         # Run a Kubernetes Job with the given image + command + environment
         try:
             log.debug(f"Creating Kubernetes job[{job_type}]: " + job_id)
-            kubejob_service.create_job(job_type=job_type, job_id=job_id, run_id=run_id, image_name=image_name, command=command, environment=environment)
+            kubejob_service.create_job(
+                job_type=job_type,
+                job_id=job_id,
+                run_id=run_id,
+                image_name=image_name,
+                command=command,
+                environment=environment
+            )
         except Exception as ex:
             log.error("Failed to create Job: " + str(ex))
             log.error(traceback.format_exc())
             raise HTTPException(status_code=400, detail="Failed to create Job: " + str(ex))
 
     else:
-        raise HTTPException(status_code=400, detail="Invalid job type: " + job_type)
+        log.error("Failed to create job - invalid job type: " + str(job_type))
+        log.error(traceback.format_exc())
+        raise HTTPException(status_code=400, detail="Invalid job type: " + str(job_type))
 
     # TODO: Set user_agent based on requestor
     user_agent = ''

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -357,7 +357,7 @@ async def create_job(
         # all EZspecificity subjobs / job steps share the same handling
         elif job_type == JobType.EZSPEC_UNIDOCK or job_type == JobType.EZSPEC_INFERENCE:
             # TODO: update command to handle ez-specificity jobs
-            command = app_config['kubernetes_jobs'][job_type]['command']
+            #command = app_config['kubernetes_jobs'][job_type]['command']
 
             # Grab our subjob_ids from the passed job_info
             job_config = json.loads(job_info.replace('\"', '"'))

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -49,12 +49,12 @@ async def create_job(
     job_id = job_id if job_id else str(kubejob_service.generate_uuid())
     #run_id = run_id if run_id else str(kubejob_service.generate_uuid())
 
-    # Check if this job_id already exists
-    statement = select(Job).where(Job.job_id == job_id)
+    # Check if this job_id already exists for this job_type
+    statement = select(Job).where(Job.type == job_type).where(Job.job_id == job_id)
     existing_jobs = await db.exec(statement)
     db_job: Job = existing_jobs.first()
-    #if db_job:
-    #    raise HTTPException(status_code=409, detail=f"Job already exists with job_id={job_id}")
+    if db_job:
+        raise HTTPException(status_code=409, detail=f"Job already exists with job_id={job_id}")
 
     # Validate Job type
     # TODO: Set command+image based on job_type
@@ -71,7 +71,7 @@ async def create_job(
         #volumes = []
         #secrets = []
 
-        if job_type == JobType.DEFAULT or job_type == JobType.TEST1 or job_type == JobType.TEST2 or job_type == JobType.TEST3:
+        if job_type == JobType.DEFAULT:
             command = app_config['kubernetes_jobs'][job_type]['command']
             environment = app_config['kubernetes_jobs'][job_type]['env'] if 'env' in app_config['kubernetes_jobs'][job_type] else []
             #initContainers = app_config['kubernetes_jobs'][job_type]['initContainers'] if 'initContainers' in app_config['kubernetes_jobs'][job_type] else []
@@ -328,9 +328,49 @@ async def create_job(
                 " && rm -rf ${JOB_OUTPUT_DIR}/cache"
             )
 
+        # EZspecificity parent job, see subjobs below
         elif job_type == JobType.EZ_SPECIFICITY:
-            #TODO: update command to handle ez-specificity jobs
+            # TODO: update command to handle ez-specificity jobs
             command = app_config['kubernetes_jobs'][job_type]['command']
+            job_config = json.loads(job_info.replace('\"', '"'))
+
+            # Generate subjob_ids, store these in job_info / pass along as environment
+            ezspec_unidock_job_id = str(kubejob_service.generate_uuid())
+            ezspec_inference_job_id = str(kubejob_service.generate_uuid())
+
+            # Preserve these subjob_ids in our job_info
+            job_config = job_config | {
+                'parent_job_id': job_id,
+                'ezspec_unidock_job_id': ezspec_unidock_job_id,
+                'ezspec_inference_job_id': ezspec_inference_job_id,
+            }
+            job_info = json.dumps(job_config).replace('"', '\"')
+
+            # Pass parent / subjob_ids along as envvars
+            environment = [
+                { "name": "PARENT_JOB_ID", "value": job_id },
+                { "name": "EZSPEC_UNIDOCK_JOB_ID", "value": ezspec_unidock_job_id },
+                { "name": "EZSPEC_INFERENCE_JOB_ID", "value": ezspec_inference_job_id }
+            ]
+
+        # all EZspecificity subjobs / job steps share the same handling
+        elif job_type == JobType.EZSPEC_UNIDOCK or job_type == JobType.EZSPEC_INFERENCE:
+            # TODO: update command to handle ez-specificity jobs
+            command = app_config['kubernetes_jobs'][job_type]['command']
+
+            # Grab our subjob_ids from the passed job_info
+            job_config = json.loads(job_info.replace('\"', '"'))
+            if job_type == JobType.EZSPEC_UNIDOCK:
+                job_id = job_config['ezspec_unidock_job_id']
+            elif job_type == JobType.EZSPEC_INFERENCE:
+                job_id = job_config['ezspec_inference_job_id']
+
+            # Pass parent / subjob_ids along as envvars
+            environment = [
+                { "name": "PARENT_JOB_ID",  "value": job_config['parent_job_id'] },
+                { "name": "EZSPEC_UNIDOCK_JOB_ID", "value": job_config['ezspec_unidock_job_id'] },
+                { "name": "EZSPEC_INFERENCE_JOB_ID", "value": job_config['ezspec_inference_job_id'] }
+            ]
 
         # Run a Kubernetes Job with the given image + command + environment
         try:

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -347,7 +347,8 @@ async def create_job(
             job_info = json.dumps(job_config).replace('"', '\"')
 
             # Pass parent / subjob_ids along as envvars
-            environment = [
+            environment += app_config['kubernetes_jobs'][job_type]['env']
+            environment += [
                 { "name": "PARENT_JOB_ID", "value": job_id },
                 { "name": "EZSPEC_UNIDOCK_JOB_ID", "value": ezspec_unidock_job_id },
                 { "name": "EZSPEC_INFERENCE_JOB_ID", "value": ezspec_inference_job_id }
@@ -366,7 +367,8 @@ async def create_job(
                 job_id = job_config['ezspec_inference_job_id']
 
             # Pass parent / subjob_ids along as envvars
-            environment = [
+            environment += app_config['kubernetes_jobs'][job_type]['env']
+            environment += [
                 { "name": "PARENT_JOB_ID",  "value": job_config['parent_job_id'] },
                 { "name": "EZSPEC_UNIDOCK_JOB_ID", "value": job_config['ezspec_unidock_job_id'] },
                 { "name": "EZSPEC_INFERENCE_JOB_ID", "value": job_config['ezspec_inference_job_id'] }

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -431,6 +431,12 @@ async def create_job(
             'email': str(db_job.email),
             'job_info': str(db_job.job_info),
         })
+    else:
+        db_job.job_info = job_info
+
+        await db.merge(db_job)
+        await db.commit()
+        await db.refresh(db_job)
 
     return JSONResponse(status_code=status.HTTP_200_OK, content={
         'job_id': str(db_job.job_id),

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -29,11 +29,16 @@ from services import kubejob_service
 from services.clean_service import CleanService
 from services.molli_service import MolliService
 from services.minio_service import MinIOService
+from services.shared import is_valid_pdb_file
 from services.somn_service import SomnService
 
 router = APIRouter()
 
 log = get_logger(__name__)
+
+# EZSpecificity input limits (mirror the frontend's MAX_ENZYMES / substrate cap)
+EZSPEC_MAX_ENZYMES = 5
+EZSPEC_MAX_SUBSTRATES = 10
 
 
 @router.post("/{job_type}/jobs", response_model=Job, tags=['Jobs'], description="Create a new run for a new or existing Job")
@@ -330,9 +335,56 @@ async def create_job(
 
         # EZspecificity parent job, see subjobs below
         elif job_type == JobType.EZ_SPECIFICITY:
-            # TODO: update command to handle ez-specificity jobs
             command = app_config['kubernetes_jobs'][job_type]['command']
             job_config = json.loads(job_info.replace('\"', '"'))
+
+            # Validate user input: we need enzymes + substrates to build the docking config
+            if 'enzymes' not in job_config or 'substrates' not in job_config:
+                raise HTTPException(status_code=400,
+                    detail='"job_info" requires "enzymes" and "substrates"')
+
+            enzymes = job_config['enzymes']
+            substrates = job_config['substrates']
+            if not isinstance(enzymes, list) or not isinstance(substrates, list):
+                raise HTTPException(status_code=400,
+                    detail='"enzymes" and "substrates" must be lists')
+            if not 1 <= len(enzymes) <= EZSPEC_MAX_ENZYMES:
+                raise HTTPException(status_code=400,
+                    detail=f'Expected 1-{EZSPEC_MAX_ENZYMES} enzyme(s), got {len(enzymes)}')
+            if not 1 <= len(substrates) <= EZSPEC_MAX_SUBSTRATES:
+                raise HTTPException(status_code=400,
+                    detail=f'Expected 1-{EZSPEC_MAX_SUBSTRATES} substrate(s), got {len(substrates)}')
+
+            # Validate each uploaded enzyme structure. The PDBs were already uploaded
+            # to {job_id}/in/ via the /upload endpoint; we re-check them here (server-side,
+            # where we can actually parse the file content) before kicking off the pipeline.
+            for enzyme in enzymes:
+                filename = enzyme.get('filename')
+                if not filename:
+                    raise HTTPException(status_code=400, detail='Each enzyme requires a "filename"')
+                content = service.get_file(job_type, f"{job_id}/in/{filename}")
+                if content is None:
+                    raise HTTPException(status_code=400,
+                        detail=f'Enzyme structure not found in uploads: {filename}')
+                if not is_valid_pdb_file(content):
+                    raise HTTPException(status_code=400,
+                        detail=f'Invalid PDB structure: {filename}')
+
+            # Write job_config.json into the parent job's input dir. coordinator.py copies
+            # the parent's in/ into each subjob, so unidock + inference both receive this
+            # config (the containers read job_config.json, not the job_info API field).
+            container_config = {
+                'enzymes': enzymes,
+                'substrates': substrates,
+            }
+            if 'docking' in job_config:
+                container_config['docking'] = job_config['docking']
+            if service.ensure_bucket_exists(job_type):
+                service.upload_file(
+                    job_type,
+                    f"{job_id}/in/job_config.json",
+                    json.dumps(container_config).encode('utf-8'),
+                )
 
             # Generate subjob_ids, store these in job_info / pass along as environment
             ezspec_unidock_job_id = str(kubejob_service.generate_uuid())

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -53,8 +53,8 @@ async def create_job(
     statement = select(Job).where(Job.type == job_type).where(Job.job_id == job_id)
     existing_jobs = await db.exec(statement)
     db_job: Job = existing_jobs.first()
-    if db_job:
-        raise HTTPException(status_code=409, detail=f"Job already exists with job_id={job_id}")
+    #if db_job:
+    #    raise HTTPException(status_code=409, detail=f"Job already exists with job_id={job_id}")
 
     # Validate Job type
     # TODO: Set command+image based on job_type

--- a/app/services/ezspecificity_service.py
+++ b/app/services/ezspecificity_service.py
@@ -1,0 +1,39 @@
+from config import get_logger
+
+log = get_logger(__name__)
+
+class EzSpecificityService:
+
+    @staticmethod
+    async def resultPostProcess(bucket_name, job_id, service, db):
+        # TODO: what format is expected for the results in the frontend?
+
+        # TODO: fetch MinIO files and present in the correct format
+        enzymes = service.get_file(bucket_name, f"{job_id}/out/Enzymes.csv")
+        substrates = service.get_file(bucket_name, f"{job_id}/out/Substrates.csv")
+        #data = service.get_file(bucket_name, f"{job_id}/out/data.csv")
+        #job_config = service.get_file(bucket_name, f"{job_id}/out/job_config.json")
+
+        return {
+            'hello': 'world'
+        }
+
+    @staticmethod
+    async def unidockResultPostProcess(bucket_name, job_id, service, db):
+        # TODO: what format is expected for the results in the frontend?
+
+        # TODO: fetch MinIO files and present in the correct format
+
+        return {
+            'hello': 'unidock'
+        }
+
+    @staticmethod
+    async def inferenceResultPostProcess(bucket_name, job_id, service, db):
+        # TODO: what format is expected for the results in the frontend?
+
+        # TODO: fetch MinIO files and present in the correct format
+
+        return {
+            'hello': 'inference'
+        }

--- a/app/services/ezspecificity_service.py
+++ b/app/services/ezspecificity_service.py
@@ -54,6 +54,8 @@ class EzSpecificityService:
         job_info = job_status.job_info
         job_config = json.loads(job_info.replace('\\"', '"'))
 
+        unidock_id = job_config['ezspec_unidock_job_id']
+
         # Fetch ezspec-unidock results
         enzyme_bytes = service.get_file(bucket_name, f"{job_id}/out/{unidock_id}/out/Enzymes.csv")
         enzymes_stream = io.StringIO(enzyme_bytes.decode('utf-8'))
@@ -77,6 +79,8 @@ class EzSpecificityService:
         job_status = await db.get(Job, job_id)
         job_info = job_status.job_info
         job_config = json.loads(job_info.replace('\\"', '"'))
+
+        inference_id = job_config['ezspec_inference_job_id']
 
         # Fetch ezspec-inference results
         results_bytes = service.get_file(bucket_name, f"{job_id}/out/{inference_id}/out/results.csv")

--- a/app/services/ezspecificity_service.py
+++ b/app/services/ezspecificity_service.py
@@ -5,6 +5,8 @@ import json
 
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
+
+from models.enums import JobType
 from models.sqlmodel.models import Job
 
 from config import get_logger
@@ -28,6 +30,30 @@ class EzSpecificityService:
         unidock_id = job_config['ezspec_unidock_job_id']
         inference_id = job_config['ezspec_inference_job_id']
 
+        unidock_results = await EzSpecificityService.unidockResultPostProcess(
+            bucket_name=JobType.EZSPEC_UNIDOCK,
+            job_id=unidock_id,
+            service=service,
+            db=db
+        )
+        inference_results = await EzSpecificityService.inferenceResultPostProcess(
+            bucket_name=JobType.EZSPEC_INFERENCE,
+            job_id=inference_id,
+            service=service,
+            db=db
+        )
+
+        return unidock_results | inference_results | { 'job_config': job_config }
+
+    @staticmethod
+    async def unidockResultPostProcess(bucket_name, job_id, service, db):
+        # TODO: what format is expected for the results in the frontend?
+
+        # TODO: fetch MinIO files and present in the correct format
+        job_status = await db.get(Job, job_id)
+        job_info = job_status.job_info
+        job_config = json.loads(job_info.replace('\\"', '"'))
+
         # Fetch ezspec-unidock results
         enzyme_bytes = service.get_file(bucket_name, f"{job_id}/out/{unidock_id}/out/Enzymes.csv")
         enzymes_stream = io.StringIO(enzyme_bytes.decode('utf-8'))
@@ -36,26 +62,11 @@ class EzSpecificityService:
         data_bytes = service.get_file(bucket_name, f"{job_id}/out/{unidock_id}/out/data.csv")
         data_stream = io.StringIO(data_bytes.decode('utf-8'))
 
-        # Fetch ezspec-inference results
-        results_bytes = service.get_file(bucket_name, f"{job_id}/out/{inference_id}/out/results.csv")
-        results_stream = io.StringIO(results_bytes.decode('utf-8'))
-
         return {
             'job_config': job_config,
             'enzymes': list(csv.reader(enzymes_stream)),
             'substrates': list(csv.reader(substrates_stream)),
             'data': list(csv.reader(data_stream)),
-            'results': list(csv.reader(results_stream)),
-        }
-
-    @staticmethod
-    async def unidockResultPostProcess(bucket_name, job_id, service, db):
-        # TODO: what format is expected for the results in the frontend?
-
-        # TODO: fetch MinIO files and present in the correct format
-
-        return {
-            'hello': 'unidock'
         }
 
     @staticmethod
@@ -63,7 +74,15 @@ class EzSpecificityService:
         # TODO: what format is expected for the results in the frontend?
 
         # TODO: fetch MinIO files and present in the correct format
+        job_status = await db.get(Job, job_id)
+        job_info = job_status.job_info
+        job_config = json.loads(job_info.replace('\\"', '"'))
+
+        # Fetch ezspec-inference results
+        results_bytes = service.get_file(bucket_name, f"{job_id}/out/{inference_id}/out/results.csv")
+        results_stream = io.StringIO(results_bytes.decode('utf-8'))
 
         return {
-            'hello': 'inference'
+            'job_config': job_config,
+            'results': list(csv.reader(results_stream)),
         }

--- a/app/services/ezspecificity_service.py
+++ b/app/services/ezspecificity_service.py
@@ -1,21 +1,51 @@
+import csv
+import io
+import json
+
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+from models.sqlmodel.models import Job
+
 from config import get_logger
+from services.minio_service import MinIOService
 
 log = get_logger(__name__)
 
 class EzSpecificityService:
 
     @staticmethod
-    async def resultPostProcess(bucket_name, job_id, service, db):
+    async def resultPostProcess(bucket_name: str, job_id: str, service: MinIOService, db: AsyncSession):
         # TODO: what format is expected for the results in the frontend?
+        # JSON array of objects w/ fields: rank, enzyme, substrate, ez_score
+        #   Alt (if inputMode != pairs): rank, complexLabel, ez_score
 
         # TODO: fetch MinIO files and present in the correct format
-        enzymes = service.get_file(bucket_name, f"{job_id}/out/Enzymes.csv")
-        substrates = service.get_file(bucket_name, f"{job_id}/out/Substrates.csv")
-        #data = service.get_file(bucket_name, f"{job_id}/out/data.csv")
-        #job_config = service.get_file(bucket_name, f"{job_id}/out/job_config.json")
+        job_status = await db.get(Job, job_id)
+        job_info = job_status.job_info
+        job_config = json.loads(job_info.replace('\\"', '"'))
+
+        unidock_id = job_config['ezspec_unidock_job_id']
+        inference_id = job_config['ezspec_inference_job_id']
+
+        # Fetch ezspec-unidock results
+        enzyme_bytes = service.get_file(bucket_name, f"{job_id}/out/{unidock_id}/out/Enzymes.csv")
+        enzymes_stream = io.StringIO(enzyme_bytes.decode('utf-8'))
+        substrate_bytes = service.get_file(bucket_name, f"{job_id}/out/{unidock_id}/out/Substrates.csv")
+        substrates_stream = io.StringIO(substrate_bytes.decode('utf-8'))
+        data_bytes = service.get_file(bucket_name, f"{job_id}/out/{unidock_id}/out/data.csv")
+        data_stream = io.StringIO(data_bytes.decode('utf-8'))
+
+        # Fetch ezspec-inference results
+        results_bytes = service.get_file(bucket_name, f"{job_id}/out/{inference_id}/out/results.csv")
+        results_stream = io.StringIO(results_bytes.decode('utf-8'))
 
         return {
-            'hello': 'world'
+            'job_config': job_config,
+            'enzymes': list(csv.reader(enzymes_stream)),
+            'substrates': list(csv.reader(substrates_stream)),
+            'data': list(csv.reader(data_stream)),
+            'results': list(csv.reader(results_stream)),
         }
 
     @staticmethod

--- a/app/services/ezspecificity_service.py
+++ b/app/services/ezspecificity_service.py
@@ -1,92 +1,165 @@
 import csv
 import io
 import json
+from typing import Any, Optional
 
-
-from sqlmodel import select
+from fastapi import HTTPException
 from sqlmodel.ext.asyncio.session import AsyncSession
-
-from models.enums import JobType
-from models.sqlmodel.models import Job
 
 from config import get_logger
 from services.minio_service import MinIOService
 
 log = get_logger(__name__)
 
+
 class EzSpecificityService:
+    """Post-process ez-specificity job output into the shape the frontend expects.
+
+    An ez-specificity *parent* job (bucket ``ez-specificity``) orchestrates two
+    subjobs whose outputs are collected under ``{job_id}/out/``:
+
+      * unidock   -> ``{job_id}/out/{unidock_id}/out/results.json`` (+ ``complexes/``)
+      * inference -> ``{job_id}/out/{inference_id}/out/results.csv``
+
+    The frontend result table consumes a flat JSON array, one row per docked
+    (enzyme, substrate) pair, with ``enzyme``, ``substrate``, ``smiles``,
+    ``complex`` (a directly-fetchable URL to the complex PDB) and ``ez_score``
+    (the inference score). ``resultPostProcess`` joins the two subjob outputs
+    into that shape; ``unidockResultPostProcess`` / ``inferenceResultPostProcess``
+    expose the individual subjob outputs (bucket ``ezspec-unidock`` /
+    ``ezspec-inference``) for debugging / reuse.
+    """
+
+    RESULTS_JSON_SUFFIX = "/results.json"
+    RESULTS_CSV_SUFFIX = "/results.csv"
 
     @staticmethod
-    async def resultPostProcess(bucket_name: str, job_id: str, service: MinIOService, db: AsyncSession):
-        # TODO: what format is expected for the results in the frontend?
-        # JSON array of objects w/ fields: rank, enzyme, substrate, ez_score
-        #   Alt (if inputMode != pairs): rank, complexLabel, ez_score
+    async def resultPostProcess(bucket_name: str, job_id: str, service: MinIOService, db: AsyncSession) -> list[dict[str, Any]]:
+        object_names = EzSpecificityService._list_output_objects(bucket_name, job_id, service)
 
-        # TODO: fetch MinIO files and present in the correct format
-        job_status = await db.get(Job, job_id)
-        job_info = job_status.job_info
-        job_config = json.loads(job_info.replace('\\"', '"'))
+        unidock_results_path = EzSpecificityService._find_suffix(object_names, EzSpecificityService.RESULTS_JSON_SUFFIX)
+        if unidock_results_path is None:
+            raise HTTPException(status_code=404, detail=f"Docking results not found for job {job_id}")
 
-        unidock_id = job_config['ezspec_unidock_job_id']
-        inference_id = job_config['ezspec_inference_job_id']
+        rows = EzSpecificityService._docking_rows_with_complexes(bucket_name, unidock_results_path, service)
 
-        unidock_results = await EzSpecificityService.unidockResultPostProcess(
-            bucket_name=JobType.EZSPEC_UNIDOCK,
-            job_id=unidock_id,
-            service=service,
-            db=db
-        )
-        inference_results = await EzSpecificityService.inferenceResultPostProcess(
-            bucket_name=JobType.EZSPEC_INFERENCE,
-            job_id=inference_id,
-            service=service,
-            db=db
-        )
+        inference_results_path = EzSpecificityService._find_suffix(object_names, EzSpecificityService.RESULTS_CSV_SUFFIX)
+        scores = EzSpecificityService._read_inference_scores(bucket_name, inference_results_path, service)
 
-        return unidock_results | inference_results | { 'job_config': job_config }
+        for row in rows:
+            key = EzSpecificityService._pair_key(row.get("enzyme_index"), row.get("substrate_index"))
+            row["ez_score"] = scores.get(key) if key is not None else None
+        return rows
 
     @staticmethod
-    async def unidockResultPostProcess(bucket_name, job_id, service, db):
-        # TODO: what format is expected for the results in the frontend?
-
-        # TODO: fetch MinIO files and present in the correct format
-        job_status = await db.get(Job, job_id)
-        job_info = job_status.job_info
-        job_config = json.loads(job_info.replace('\\"', '"'))
-
-        unidock_id = job_config['ezspec_unidock_job_id']
-
-        # Fetch ezspec-unidock results
-        enzyme_bytes = service.get_file(bucket_name, f"{job_id}/out/{unidock_id}/out/Enzymes.csv")
-        enzymes_stream = io.StringIO(enzyme_bytes.decode('utf-8'))
-        substrate_bytes = service.get_file(bucket_name, f"{job_id}/out/{unidock_id}/out/Substrates.csv")
-        substrates_stream = io.StringIO(substrate_bytes.decode('utf-8'))
-        data_bytes = service.get_file(bucket_name, f"{job_id}/out/{unidock_id}/out/data.csv")
-        data_stream = io.StringIO(data_bytes.decode('utf-8'))
-
-        return {
-            'job_config': job_config,
-            'enzymes': list(csv.reader(enzymes_stream)),
-            'substrates': list(csv.reader(substrates_stream)),
-            'data': list(csv.reader(data_stream)),
-        }
+    async def unidockResultPostProcess(bucket_name: str, job_id: str, service: MinIOService, db: AsyncSession) -> list[dict[str, Any]]:
+        """Docking-only output for a single ezspec-unidock subjob ({job_id}/out/results.json)."""
+        object_names = EzSpecificityService._list_output_objects(bucket_name, job_id, service)
+        results_path = EzSpecificityService._find_suffix(object_names, EzSpecificityService.RESULTS_JSON_SUFFIX)
+        if results_path is None:
+            raise HTTPException(status_code=404, detail=f"Docking results not found for job {job_id}")
+        return EzSpecificityService._docking_rows_with_complexes(bucket_name, results_path, service)
 
     @staticmethod
-    async def inferenceResultPostProcess(bucket_name, job_id, service, db):
-        # TODO: what format is expected for the results in the frontend?
+    async def inferenceResultPostProcess(bucket_name: str, job_id: str, service: MinIOService, db: AsyncSession) -> list[dict[str, Any]]:
+        """Score rows for a single ezspec-inference subjob ({job_id}/out/results.csv)."""
+        object_names = EzSpecificityService._list_output_objects(bucket_name, job_id, service)
+        results_path = EzSpecificityService._find_suffix(object_names, EzSpecificityService.RESULTS_CSV_SUFFIX)
+        if results_path is None:
+            raise HTTPException(status_code=404, detail=f"Inference results not found for job {job_id}")
+        content = service.get_file(bucket_name, results_path)
+        if content is None:
+            raise HTTPException(status_code=404, detail=f"Unable to read inference results: {results_path}")
+        return list(csv.DictReader(io.StringIO(content.decode("utf-8"))))
 
-        # TODO: fetch MinIO files and present in the correct format
-        job_status = await db.get(Job, job_id)
-        job_info = job_status.job_info
-        job_config = json.loads(job_info.replace('\\"', '"'))
+    # ------------------------------------------------------------------ helpers
 
-        inference_id = job_config['ezspec_inference_job_id']
+    @staticmethod
+    def _docking_rows_with_complexes(bucket_name: str, results_json_path: str, service: MinIOService) -> list[dict[str, Any]]:
+        """Read a docking results.json and turn each ``complex`` filename into a URL.
 
-        # Fetch ezspec-inference results
-        results_bytes = service.get_file(bucket_name, f"{job_id}/out/{inference_id}/out/results.csv")
-        results_stream = io.StringIO(results_bytes.decode('utf-8'))
+        Complexes live alongside results.json: ``{.../out}/complexes/<complex>``.
+        """
+        docking_rows = EzSpecificityService._read_docking_results(bucket_name, results_json_path, service)
+        complexes_prefix = results_json_path[: -len(EzSpecificityService.RESULTS_JSON_SUFFIX)]
 
-        return {
-            'job_config': job_config,
-            'results': list(csv.reader(results_stream)),
-        }
+        rows: list[dict[str, Any]] = []
+        for entry in docking_rows:
+            complex_name = entry.get("complex")
+            complex_url = None
+            if complex_name:
+                complex_url = service.get_file_url(bucket_name, f"{complexes_prefix}/complexes/{complex_name}")
+            rows.append({**entry, "complex": complex_url})
+        return rows
+
+    @staticmethod
+    def _list_output_objects(bucket_name: str, job_id: str, service: MinIOService) -> list[str]:
+        objects = service.list_files(bucket_name, f"{job_id}/out/", recursive=True)
+        if objects is None:
+            return []
+        return [obj.object_name for obj in objects]
+
+    @staticmethod
+    def _find_suffix(object_names: list[str], suffix: str) -> Optional[str]:
+        # Prefer the shallowest match so we don't pick up nested/duplicated files.
+        matches = sorted((name for name in object_names if name.endswith(suffix)), key=lambda n: n.count("/"))
+        return matches[0] if matches else None
+
+    @staticmethod
+    def _read_docking_results(bucket_name: str, object_name: str, service: MinIOService) -> list[dict[str, Any]]:
+        content = service.get_file(bucket_name, object_name)
+        if content is None:
+            raise HTTPException(status_code=404, detail=f"Unable to read docking results: {object_name}")
+        try:
+            data = json.loads(content.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError) as err:
+            log.error(f"Failed to parse docking results {object_name}: {err}")
+            raise HTTPException(status_code=500, detail="Malformed docking results")
+        if not isinstance(data, list):
+            raise HTTPException(status_code=500, detail="Unexpected docking results format")
+        return data
+
+    @staticmethod
+    def _read_inference_scores(bucket_name: str, object_name: Optional[str], service: MinIOService) -> dict[tuple[int, int], float]:
+        """Map (enzyme_index, substrate_index) -> inference score.
+
+        We deliberately join on the enzyme/substrate indices rather than the CSV's
+        "Dock Index" column: the inference container overwrites that column with an
+        internal value, so it no longer matches the docking output.
+        """
+        if object_name is None:
+            return {}
+        content = service.get_file(bucket_name, object_name)
+        if content is None:
+            return {}
+
+        scores: dict[tuple[int, int], float] = {}
+        reader = csv.DictReader(io.StringIO(content.decode("utf-8")))
+        for row in reader:
+            key = EzSpecificityService._pair_key(row.get("Enzyme Index"), row.get("Substrate Index"))
+            score = EzSpecificityService._parse_float(row.get("score"))
+            if key is not None and score is not None:
+                scores[key] = score
+        return scores
+
+    @staticmethod
+    def _pair_key(enzyme_index: Any, substrate_index: Any) -> Optional[tuple[int, int]]:
+        enzyme = EzSpecificityService._parse_int(enzyme_index)
+        substrate = EzSpecificityService._parse_int(substrate_index)
+        if enzyme is None or substrate is None:
+            return None
+        return (enzyme, substrate)
+
+    @staticmethod
+    def _parse_int(value: Any) -> Optional[int]:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _parse_float(value: Any) -> Optional[float]:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None

--- a/app/services/kubejob_service.py
+++ b/app/services/kubejob_service.py
@@ -7,7 +7,7 @@ from kubernetes.client.rest import ApiException
 import os
 import yaml
 import json
-from jinja2 import Template
+from jinja2 import Template, Environment, BaseLoader
 import uuid
 
 import time
@@ -19,7 +19,7 @@ from sqlmodel import Session
 
 from config import app_config, get_logger, RELEASE_NAME, STATUS_OK, STATUS_ERROR, DEBUG, MINIO_SERVER, MINIO_ACCESS_KEY, \
     MINIO_SECRET_KEY, SQLALCHEMY_DATABASE_URL
-from models.enums import JobStatus, JobType
+from models.enums import JobStatus, JobType, JobTypes, ExampleJobTypes
 from models.sqlmodel.db import get_session, engine
 from models.sqlmodel.models import Job
 import sqlalchemy as db
@@ -29,6 +29,11 @@ from services.minio_service import MinIOService
 
 log = get_logger(__name__)
 
+# Initialize your environment
+env = Environment(loader=BaseLoader())
+
+# Register the to_json filter
+env.filters['to_json'] = json.dumps
 
 ## Load Kubernetes cluster config. Unhandled exception if not in Kubernetes environment.
 try:
@@ -131,6 +136,10 @@ class KubeEventWatcher:
 
     def send_notification_email(self, job_id, job_type, updated_job, new_phase):
         job_type_name = 'Unknown'
+        if job_type in ExampleJobTypes:
+            log.debug(f'Skipping notification email for ExampleJobType: {str(job_type)}')
+            return
+
         if 'novostoic' in job_type:
             novostoic_frontend_url = app_config['novostoic_frontend_url']
             if job_type == JobType.NOVOSTOIC_PATHWAYS:
@@ -146,7 +155,7 @@ class KubeEventWatcher:
                 results_url = f'{novostoic_frontend_url}/thermodynamical-feasibility/result/{updated_job.job_id}'
                 job_type_name = 'dGPredictor'
             else:
-                raise ValueError(f"Unrecognized novoStoic subjob type {job_type} not in existing Job Types {JobType}")
+                raise ValueError(f"Unrecognized novoStoic subjob type {job_type} not in existing Job Types {str(JobTypes)}")
         elif job_type == JobType.SOMN:
             somn_frontend_url = app_config['somn_frontend_url']
             results_url = f'{somn_frontend_url}/results/{updated_job.job_id}'
@@ -177,8 +186,8 @@ class KubeEventWatcher:
             #self.logger.warning(f'WARNING: Skipping sending notification email for {job_type} - {job_id}')
             return
 
-        else: 
-            raise ValueError(f"Unrecognized job type {job_type} not in existing Job Types {JobType}")
+        else:
+            raise ValueError(f"Unrecognized job type {job_type} not in existing Job Types {str(JobTypes)}")
 
         job_id = updated_job.job_id
 
@@ -485,6 +494,8 @@ def delete_job(job_id: str) -> None:
     except Exception as e:
         log.error(f'''Error deleting Kubernetes Job: {e}''')
         raise
+
+    # XXX: Jobs don't currently use a configmap, but they could...
     # try:
     #     api_response = api_v1.delete_namespaced_config_map(
     #         namespace=namespace,
@@ -501,7 +512,9 @@ def delete_job(job_id: str) -> None:
     #     raise
 
 
-def create_job(job_type, job_id, run_id=None, image_name=None, command=None, owner_id=None, replicas=1, environment=[]):
+def create_job(job_type, job_id, run_id=None, image_name=None, command=None, owner_id=None, replicas=1, environment=None):
+    if environment is None:
+        environment = []
     log.info(f'Creating KubeJob with ID={job_id}')
 
     if job_type not in app_config['kubernetes_jobs']:
@@ -525,7 +538,8 @@ def create_job(job_type, job_id, run_id=None, image_name=None, command=None, own
     try:
         pullPolicy = app_config['kubernetes_jobs'][job_type]['imagePullPolicy']
     except:
-        pullPolicy = 'Always' if image_name in [':latest', ':dev'] else 'IfNotPresent'
+        pullPolicy = 'Always'
+        log.debug(f"Using default: pullPolicy=Always")
 
     response = {
         'job_id': None,
@@ -558,11 +572,15 @@ def create_job(job_type, job_id, run_id=None, image_name=None, command=None, own
         #     'subPath': 'positions.csv',
         #     'readOnly': True,
         # }]
+
+        default_job_vols = app_config['kubernetes_jobs']['defaults']['volumes']
+        individual_job_vols = app_config['kubernetes_jobs'][job_type]['volumes'] if 'volumes' in app_config['kubernetes_jobs'][job_type] else []
+
         all_volumes = []
-        for volume in app_config['kubernetes_jobs']['defaults']['volumes']:
+        for volume in default_job_vols:
             all_volumes.append(volume)
         if job_type != JobType.DEFAULT:
-            for volume in app_config['kubernetes_jobs'][job_type]['volumes']:
+            for volume in individual_job_vols:
                 all_volumes.append(volume)
 
         # Include secrets, if necessary (e.g. ReactionMiner for HuggingFace API token)
@@ -579,7 +597,7 @@ def create_job(job_type, job_id, run_id=None, image_name=None, command=None, own
 
         with open(os.path.join(os.path.dirname(__file__), 'templates', templateFile)) as f:
             templateText = f.read()
-        jinja_template = Template(templateText)
+        jinja_template = env.from_string(templateText)
 
         log.debug(f'Creating jinja with jinja_template={templateText}')
 
@@ -612,6 +630,7 @@ def create_job(job_type, job_id, run_id=None, image_name=None, command=None, own
             job_output_dir=job_output_dir,
             job_input_dir=job_input_dir,
             project_subpath=project_subpath,
+            initContainers=app_config['kubernetes_jobs'][job_type]['initContainers'] if 'initContainers' in app_config['kubernetes_jobs'][job_type] else [],
             securityContext=app_config['kubernetes_jobs'][job_type]['securityContext'] if 'securityContext' in app_config['kubernetes_jobs'][job_type] else None,
             workingVolume=app_config['kubernetes_jobs']['defaults']['workingVolume'],
             volumes=all_volumes,

--- a/app/services/kubejob_service.py
+++ b/app/services/kubejob_service.py
@@ -70,9 +70,9 @@ api_v1 = client.CoreV1Api()
 #            w.stop()
 
 
-def download_remote_directory_from_minio(remote_path: str, bucket_name: str, target_directory: str = ''):
+def download_remote_directory_from_minio(minio_server:str, remote_path: str, bucket_name: str, target_directory: str = ''):
     minio = Minio(
-        MINIO_SERVER,
+        minio_server,
         access_key=MINIO_ACCESS_KEY,
         secret_key=MINIO_SECRET_KEY,
         secure=False
@@ -85,13 +85,13 @@ def download_remote_directory_from_minio(remote_path: str, bucket_name: str, tar
 
 
 # Upload a local directory recursively to MinIO
-def upload_local_directory_to_minio(local_path: str, bucket_name: str, minio_prefix: str = ""):
+def upload_local_directory_to_minio(minio_server:str, local_path: str, bucket_name: str, minio_prefix: str = ""):
     if not os.path.isdir(local_path):
         log.warning('Not a directory: ' + local_path)
         return False
 
     minioClient = Minio(
-        MINIO_SERVER,
+        minio_server,
         access_key=MINIO_ACCESS_KEY,
         secret_key=MINIO_SECRET_KEY,
         secure=False

--- a/app/services/kubejob_service.py
+++ b/app/services/kubejob_service.py
@@ -70,9 +70,9 @@ api_v1 = client.CoreV1Api()
 #            w.stop()
 
 
-def download_remote_directory_from_minio(minio_server:str, remote_path: str, bucket_name: str, target_directory: str = ''):
+def download_remote_directory_from_minio(remote_path: str, bucket_name: str, target_directory: str = ''):
     minio = Minio(
-        minio_server,
+        MINIO_SERVER,
         access_key=MINIO_ACCESS_KEY,
         secret_key=MINIO_SECRET_KEY,
         secure=False
@@ -85,13 +85,13 @@ def download_remote_directory_from_minio(minio_server:str, remote_path: str, buc
 
 
 # Upload a local directory recursively to MinIO
-def upload_local_directory_to_minio(minio_server:str, local_path: str, bucket_name: str, minio_prefix: str = ""):
+def upload_local_directory_to_minio(local_path: str, bucket_name: str, minio_prefix: str = ""):
     if not os.path.isdir(local_path):
         log.warning('Not a directory: ' + local_path)
         return False
 
     minioClient = Minio(
-        minio_server,
+        MINIO_SERVER,
         access_key=MINIO_ACCESS_KEY,
         secret_key=MINIO_SECRET_KEY,
         secure=False

--- a/app/services/kubejob_service.py
+++ b/app/services/kubejob_service.py
@@ -179,14 +179,15 @@ class KubeEventWatcher:
             openenzyemdb_frontend_url = app_config['openenzymedb_frontend_url']
             results_url = f'{openenzyemdb_frontend_url}/enzyme-recommendation/result/{updated_job.job_id}'
             job_type_name = 'OpenEnzymeDB - Enzyme Recommendation'
-
-        elif job_type == JobType.ML_SIMPLEFOLD:
-            # SimpleFold jobs don't have a frontend URL yet - skip email for now
-            return
-
-        # OED & CLEANDB jobs are very fast - no need to send notification email
-        elif job_type.startswith('oed-') or job_type.startswith('cleandb-'):
-            #self.logger.warning(f'WARNING: Skipping sending notification email for {job_type} - {job_id}')
+        elif job_type == JobType.EZ_SPECIFICITY:
+            ezspecificity_frontend_url = app_config['ezspecificity_frontend_url']
+            results_url = f'{ezspecificity_frontend_url}/result/{updated_job.job_id}'
+            job_type_name = 'EZspecificity'
+        elif job_type in JobTypes:
+            # OED & CLEANDB jobs are very fast - no need to send notification email
+            # No need to notify about EZspec intermediary steps
+            # No need to notify about ML Simplefold
+            log.warning(f'Skipping notification email for unconfigured JobType: {job_type}')
             return
 
         else:
@@ -197,9 +198,11 @@ class KubeEventWatcher:
         # Send email notification about success/failure
         if new_phase == JobStatus.COMPLETED and updated_job.email and self.should_send_email(job_type, job_id):
             try:
-                self.email_service.send_email(updated_job.email,
-                                              f'''Result for your {job_type_name} Job ({job_id}) is ready''',
-                                              f'''The result for your {job_type_name} Job is available at {results_url}''')
+                self.email_service.send_email(
+                    updated_job.email,
+                    f'''Result for your {job_type_name} Job ({job_id}) is ready''',
+                    f'''The result for your {job_type_name} Job is available at {results_url}'''
+                )
                 self.mark_email_as_sent(job_type, job_id, success=True)
             except Exception as e:
                 log.error(f'Failed to send email notification on success: {str(e)}')

--- a/app/services/minio_service.py
+++ b/app/services/minio_service.py
@@ -57,17 +57,30 @@ class MinIOService:
             urls = []
             objects = self.client.list_objects(bucket_name, prefix=path, recursive=True)
             for obj in objects:
-                url = self.client.presigned_get_object(bucket_name, obj.object_name)
-                url = url.split('?', 1)[0]
-                parsed_url = urlparse(url)
-                minio_api_url = urlunparse(
-                    ("https", self.minio_api_baseURL, parsed_url.path, parsed_url.params, parsed_url.query, parsed_url.fragment)
-                )
-                # urls.append(url)
-                urls.append(minio_api_url)
+                urls.append(self._public_object_url(bucket_name, obj.object_name))
             return urls
         except S3Error as err:
             log.error("Error: ", err)
+
+    def get_file_url(self, bucket_name, object_name):
+        """Build a public (unsigned) download URL for a single object.
+
+        Mirrors get_file_urls but for a known object path, so callers can turn a
+        MinIO object into a URL the frontend can fetch directly (e.g. a docked
+        complex PDB rendered in the 3D viewer).
+        """
+        try:
+            return self._public_object_url(bucket_name, object_name)
+        except S3Error as err:
+            log.error("Error: ", err)
+
+    def _public_object_url(self, bucket_name, object_name):
+        url = self.client.presigned_get_object(bucket_name, object_name)
+        url = url.split('?', 1)[0]
+        parsed_url = urlparse(url)
+        return urlunparse(
+            ("https", self.minio_api_baseURL, parsed_url.path, parsed_url.params, parsed_url.query, parsed_url.fragment)
+        )
 
     def ensure_bucket_exists(self, bucket_name):
         if self.client.bucket_exists(bucket_name):

--- a/app/services/shared.py
+++ b/app/services/shared.py
@@ -79,9 +79,13 @@ def get_iupac_name(smiles: str) -> str:
         return None
     
     
-def is_valid_pdb_file(file_content: bytes) -> bool:
+def is_valid_pdb_file(file_content) -> bool:
     try:
+        # RDKit's MolFromPDBBlock expects the PDB block as text; callers may pass
+        # raw bytes (e.g. from an upload or MinIO), so decode to str first.
+        if isinstance(file_content, (bytes, bytearray)):
+            file_content = file_content.decode('utf-8', errors='ignore')
         mol = Chem.MolFromPDBBlock(file_content)
         return mol is not None
-    except Exception as e:
+    except Exception:
         return False

--- a/app/services/templates/job.tpl.yaml
+++ b/app/services/templates/job.tpl.yaml
@@ -73,6 +73,51 @@ spec:
             {%- endif %}
         {%- endfor %}
       initContainers:
+      {%- for init in initContainers %}
+      - name: "{{ init.name }}"
+        image: "{{ init.image }}"
+        imagePullPolicy: Always
+        {%- if init.command %}
+        command: [ "{{ init.command | join('", "') }}" ]
+        {%- endif %}
+        {%- if init.args %}
+        args:
+          {%- for arg in init.args %}
+          - |
+{{ arg | indent(12, first=True) }}
+          {%- endfor %}
+        {%- endif %}
+        env:
+        - name: "JOB_ID"
+          value: "{{ jobId }}"
+        - name: "JOB_TYPE"
+          value: "{{ jobType }}"
+        - name: "MINIO_SERVER"
+          value: "{{ minio_server }}"
+        {%- for env_item in init.env %}
+        - name: "{{ env_item.name }}"
+          {%- if env_item.value is defined %}
+          value: "{{ env_item.value }}"
+          {%- elif env_item.valueFrom is defined %}
+          valueFrom:
+            {{ env_item.valueFrom | to_json }}
+          {%- endif %}
+        {%- endfor %}
+        {% for env in environment %}
+        - name: "{{ env.name }}"
+          value: "{{ env.value }}"
+        {% endfor %}
+        volumeMounts:
+          - name: "shared-storage"
+            mountPath: "/uws"
+            subPath: "uws"
+          - name: server-config
+            mountPath: /code/app/cfg/config.yaml
+            subPath: config.yaml
+          - name: server-secret
+            mountPath: /code/app/cfg/secret.yaml
+            subPath: secret.yaml
+      {%- endfor %}
       - name: init
         image: moleculemaker/mmli-backend:kubejob
         imagePullPolicy: Always

--- a/app/services/templates/job.tpl.yaml
+++ b/app/services/templates/job.tpl.yaml
@@ -119,7 +119,7 @@ spec:
             subPath: secret.yaml
       {%- endfor %}
       - name: init
-        image: moleculemaker/mmli-backend:pr-103
+        image: moleculemaker/mmli-backend:main
         imagePullPolicy: Always
         # securityContext:
         #   runAsUser: 0

--- a/app/services/templates/job.tpl.yaml
+++ b/app/services/templates/job.tpl.yaml
@@ -119,7 +119,7 @@ spec:
             subPath: secret.yaml
       {%- endfor %}
       - name: init
-        image: moleculemaker/mmli-backend:pr-101
+        image: moleculemaker/mmli-backend:pr-103
         imagePullPolicy: Always
         # securityContext:
         #   runAsUser: 0
@@ -218,6 +218,12 @@ spec:
           - name: "shared-storage"
             mountPath: "/uws"
             subPath: "{{ workingVolume.subPath }}"
+          - name: server-config
+            mountPath: /code/app/cfg/config.yaml
+            subPath: config.yaml
+          - name: server-secret
+            mountPath: /code/app/cfg/secret.yaml
+            subPath: secret.yaml
         {%- for volume in volumes %}
           - name: {{ volume.name }}
             mountPath: "{{ volume.mountPath | replace('JOB_ID',jobId) }}"
@@ -232,7 +238,7 @@ spec:
         {%- endfor %}
       containers:
       - name: post-job
-        image: "moleculemaker/mmli-backend:pr-101"
+        image: "moleculemaker/mmli-backend:pr-103"
         imagePullPolicy: Always
         command:
         - 'bash'

--- a/app/services/templates/job.tpl.yaml
+++ b/app/services/templates/job.tpl.yaml
@@ -238,7 +238,7 @@ spec:
         {%- endfor %}
       containers:
       - name: post-job
-        image: "moleculemaker/mmli-backend:pr-103"
+        image: moleculemaker/mmli-backend:main
         imagePullPolicy: Always
         command:
         - 'bash'

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -64,6 +64,7 @@ spec:
       containers:
         - name: mmli-fastapi
           image: {{ .Values.controller.image }}
+          imagePullPolicy: {{ .Values.controller.imagePullPolicy | default "Always" }}
           volumeMounts:
             - name: server-config
               mountPath: /code/app/cfg/config.yaml

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   selector:
     app: mmli-fastapi
-  type: ClusterIP
+  type: {{ .Values.service.type | default "ClusterIP" }}
   ports:
     - protocol: "TCP"
       port: 8080

--- a/chart/values.local.yaml
+++ b/chart/values.local.yaml
@@ -1,6 +1,9 @@
 ingress:
   ingressClassName: nginx
 
+service:
+  type: LoadBalancer
+
 config:
   existingSecret: mmli-backend-secrets
   external:
@@ -10,7 +13,8 @@ config:
       frontendBaseUrl: "http://localhost:4200"
 
 controller:
-  image: moleculemaker/mmli-backend:kubejob
+  image: moleculemaker/mmli-backend:dependency-jobs
+  impagePullPolicy: Always
 
   # Change to local chemscraper service URL if deployed in local cluster
   # TODO: fit this into new config structure
@@ -39,6 +43,8 @@ minio:
   enabled: true
   apiIngress:
     ingressClassName: nginx
+  service:
+    type: LoadBalancer
   ingress:
     ingressClassName: nginx
 #  global:

--- a/chart/values.local.yaml
+++ b/chart/values.local.yaml
@@ -6,19 +6,27 @@ service:
 
 config:
   existingSecret: mmli-backend-secrets
+  kubernetes_jobs:
+    ez-specificity:
+      env:
+        - name: MINIO_SERVER
+          value: "http://mmli-backend-minio.mmli.svc.cluster.local:9000"
+        - name: MMLI_BACKEND_HOST
+          value: "http://mmli-backend.mmli.svc.cluster.local:8080"
   external:
     chemscraper:
       # Change to local chemscraper service URL if deployed in local cluster
-      apiBaseUrl: "https://chemscraper.backend.staging.mmli1.ncsa.illinois.edu"
+      apiBaseUrl: "https://chemscraper.backend.staging.mmli2.ncsa.illinois.edu"
       frontendBaseUrl: "http://localhost:4200"
 
 controller:
-  image: moleculemaker/mmli-backend:dependency-jobs
-  impagePullPolicy: Always
+  image: moleculemaker/mmli-backend:coord-jobs
+  imagePullPolicy: Always
 
   # Change to local chemscraper service URL if deployed in local cluster
   # TODO: fit this into new config structure
-  chemscraper_url: "https://chemscraper.backend.staging.mmli1.ncsa.illinois.edu"
+  chemscraper_url: "https://chemscraper.backend.staging.mmli2.ncsa.illinois.edu"
+  ezspecificity_frontend_url: "http://localhost:4200"
   novostoic_frontend_url: "http://localhost:4200"
   somn_frontend_url: "http://localhost:4200"
   chemscraper_frontend_url: "http://localhost:4200"

--- a/chart/values.local.yaml
+++ b/chart/values.local.yaml
@@ -12,7 +12,7 @@ config:
         - name: MINIO_SERVER
           value: "mmli-backend-minio.mmli.svc.cluster.local:9000"
         - name: MMLI_BACKEND_HOST
-          value: "mmli-backend.mmli.svc.cluster.local:8080"
+          value: "http://mmli-backend.mmli.svc.cluster.local:8080"
 
 # Uncomment for a way to test multi-step workflow locally
 #    ezspec-unidock:

--- a/chart/values.local.yaml
+++ b/chart/values.local.yaml
@@ -13,6 +13,18 @@ config:
           value: "http://mmli-backend-minio.mmli.svc.cluster.local:9000"
         - name: MMLI_BACKEND_HOST
           value: "http://mmli-backend.mmli.svc.cluster.local:8080"
+
+# Uncomment for a way to test multi-step workflow locally
+#    ezspec-unidock:
+#      # Example job image name + command combo
+#      image: "ubuntu:jammy"
+#      command: "echo 5 > ${JOB_OUTPUT_DIR}/step1.out"
+
+# Uncomment for a way to test multi-step workflow locally
+#    ezspec-inference:
+#      # Example job image name + command combo
+#      image: "ubuntu:jammy"
+#      command: "echo 10 > ${JOB_OUTPUT_DIR}/step2.out"
   external:
     chemscraper:
       # Change to local chemscraper service URL if deployed in local cluster

--- a/chart/values.local.yaml
+++ b/chart/values.local.yaml
@@ -10,9 +10,9 @@ config:
     ez-specificity:
       env:
         - name: MINIO_SERVER
-          value: "http://mmli-backend-minio.mmli.svc.cluster.local:9000"
+          value: "mmli-backend-minio.mmli.svc.cluster.local:9000"
         - name: MMLI_BACKEND_HOST
-          value: "http://mmli-backend.mmli.svc.cluster.local:8080"
+          value: "mmli-backend.mmli.svc.cluster.local:8080"
 
 # Uncomment for a way to test multi-step workflow locally
 #    ezspec-unidock:

--- a/chart/values.mmli2.prod.yaml
+++ b/chart/values.mmli2.prod.yaml
@@ -183,6 +183,14 @@ config:
           key: nvidia.com/gpu
           operator: Exists
     ez-specificity:
+      # Coordinator is CPU-only (no GPU); it must tolerate the worker-job taint
+      # or it can't schedule on the dedicated job nodes (general nodes are full).
+      nodeSelector:
+        ncsa.role: worker-job
+      tolerations:
+        - effect: NoSchedule
+          key: mmli.role
+          operator: Exists
       env:
         - name: MINIO_SERVER
           value: "mmli-backend-minio.alphasynthesis.svc.cluster.local:9000"

--- a/chart/values.mmli2.prod.yaml
+++ b/chart/values.mmli2.prod.yaml
@@ -187,7 +187,7 @@ config:
         - name: MINIO_SERVER
           value: "mmli-backend-minio.alphasynthesis.svc.cluster.local:9000"
         - name: MMLI_BACKEND_HOST
-          value: "mmli-backend.alphasynthesis.svc.cluster.local:8080"
+          value: "http://mmli-backend.alphasynthesis.svc.cluster.local:8080"
     ezspec-unidock:
       runtimeClassName: nvidia
       nodeSelector:
@@ -231,6 +231,7 @@ config:
   # Change to prod service URLs (used for email notifications)
   chemscraper_url: "http://chemscraper-services.alphasynthesis.svc.cluster.local:8000"
   chemscraper_frontend_url: "https://chemscraper.platform.moleculemaker.org"
+  ezspecificity_frontend_url: "https://ezspecificity.platform.moleculemaker.org"
   novostoic_frontend_url: "https://novostoic.platform.moleculemaker.org"
   somn_frontend_url: "https://somn.platform.moleculemaker.org"
   clean_frontend_url: "https://clean.platform.moleculemaker.org"

--- a/chart/values.mmli2.prod.yaml
+++ b/chart/values.mmli2.prod.yaml
@@ -182,6 +182,12 @@ config:
         - effect: NoSchedule
           key: nvidia.com/gpu
           operator: Exists
+    ez-specificity:
+      env:
+        - name: MINIO_SERVER
+          value: "http://mmli-backend-minio.alphasynthesis.svc.cluster.local:9000"
+        - name: MMLI_BACKEND_HOST
+          value: "http://mmli-backend.alphasynthesis.svc.cluster.local:8080"
     ezspec-unidock:
       runtimeClassName: nvidia
       nodeSelector:

--- a/chart/values.mmli2.prod.yaml
+++ b/chart/values.mmli2.prod.yaml
@@ -182,6 +182,41 @@ config:
         - effect: NoSchedule
           key: nvidia.com/gpu
           operator: Exists
+    ezspec-unidock:
+      runtimeClassName: nvidia
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+      resources:
+        limits:
+          cpu: "4"
+          memory: 16Gi  # 32Gi ?
+          nvidia.com/gpu: "1"
+        requests:
+          cpu: "2"
+          memory: 8Gi  # 16Gi ?
+          nvidia.com/gpu: "1"
+    ezspec-inference:
+      runtimeClassName: nvidia
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+
+      resources:
+        limits:
+          cpu: "4"
+          memory: 16Gi  # 32Gi ?
+          nvidia.com/gpu: "1"
+        requests:
+          cpu: "2"
+          memory: 8Gi  # 16Gi ?
+          nvidia.com/gpu: "1"
   external:
     chemscraper:
       apiBaseUrl: "http://chemscraper-services.alphasynthesis.svc.cluster.local:8000"

--- a/chart/values.mmli2.prod.yaml
+++ b/chart/values.mmli2.prod.yaml
@@ -185,9 +185,9 @@ config:
     ez-specificity:
       env:
         - name: MINIO_SERVER
-          value: "http://mmli-backend-minio.alphasynthesis.svc.cluster.local:9000"
+          value: "mmli-backend-minio.alphasynthesis.svc.cluster.local:9000"
         - name: MMLI_BACKEND_HOST
-          value: "http://mmli-backend.alphasynthesis.svc.cluster.local:8080"
+          value: "mmli-backend.alphasynthesis.svc.cluster.local:8080"
     ezspec-unidock:
       runtimeClassName: nvidia
       nodeSelector:

--- a/chart/values.mmli2.staging.yaml
+++ b/chart/values.mmli2.staging.yaml
@@ -166,6 +166,40 @@ config:
         - effect: NoSchedule
           key: nvidia.com/gpu
           operator: Exists
+    ezspec-unidock:
+      runtimeClassName: nvidia
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+      resources:
+        limits:
+          cpu: "4"
+          memory: 16Gi  # 32Gi ?
+          nvidia.com/gpu: "1"
+        requests:
+          cpu: "2"
+          memory: 8Gi  # 16Gi ?
+          nvidia.com/gpu: "1"
+    ezspec-inference:
+      runtimeClassName: nvidia
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+      resources:
+        limits:
+          cpu: "4"
+          memory: 16Gi  # 32Gi ?
+          nvidia.com/gpu: "1"
+        requests:
+          cpu: "2"
+          memory: 8Gi  # 16Gi ?
+          nvidia.com/gpu: "1"
   minio:
     server: "mmli-backend-staging-minio.staging.svc.cluster.local:9000"
     apiBaseUrl: "minioapi.mmli.fastapi.staging.mmli2.ncsa.illinois.edu"

--- a/chart/values.mmli2.staging.yaml
+++ b/chart/values.mmli2.staging.yaml
@@ -166,6 +166,12 @@ config:
         - effect: NoSchedule
           key: nvidia.com/gpu
           operator: Exists
+    ez-specificity:
+      env:
+        - name: MINIO_SERVER
+          value: "http://mmli-backend-staging-minio.staging.svc.cluster.local:9000"
+        - name: MMLI_BACKEND_HOST
+          value: "http://mmli-backend-staging.staging.svc.cluster.local:8080"
     ezspec-unidock:
       runtimeClassName: nvidia
       nodeSelector:

--- a/chart/values.mmli2.staging.yaml
+++ b/chart/values.mmli2.staging.yaml
@@ -171,7 +171,7 @@ config:
         - name: MINIO_SERVER
           value: "mmli-backend-staging-minio.staging.svc.cluster.local:9000"
         - name: MMLI_BACKEND_HOST
-          value: "mmli-backend-staging.staging.svc.cluster.local:8080"
+          value: "http://mmli-backend-staging.staging.svc.cluster.local:8080"
     ezspec-unidock:
       runtimeClassName: nvidia
       nodeSelector:
@@ -217,6 +217,7 @@ config:
   # Change to staging service URLs (used for email notifications)
   chemscraper_url: "http://chemscraper-services-staging.staging.svc.cluster.local:8000"
   chemscraper_frontend_url: "https://chemscraper.frontend.staging.mmli2.ncsa.illinois.edu"
+  ezspecificity_frontend_url: "https://ezspecificity.frontend.staging.mmli2.ncsa.illinois.edu"
   novostoic_frontend_url: "https://novostoic.frontend.staging.mmli2.ncsa.illinois.edu"
   somn_frontend_url: "https://somn.frontend.staging.mmli2.ncsa.illinois.edu"
   clean_frontend_url: "https://clean.frontend.staging.mmli2.ncsa.illinois.edu"

--- a/chart/values.mmli2.staging.yaml
+++ b/chart/values.mmli2.staging.yaml
@@ -167,6 +167,14 @@ config:
           key: nvidia.com/gpu
           operator: Exists
     ez-specificity:
+      # Coordinator is CPU-only (no GPU); it must tolerate the worker-job taint
+      # or it can't schedule on the dedicated job nodes (general nodes are full).
+      nodeSelector:
+        ncsa.role: worker-job
+      tolerations:
+        - effect: NoSchedule
+          key: mmli.role
+          operator: Exists
       env:
         - name: MINIO_SERVER
           value: "mmli-backend-staging-minio.staging.svc.cluster.local:9000"

--- a/chart/values.mmli2.staging.yaml
+++ b/chart/values.mmli2.staging.yaml
@@ -169,9 +169,9 @@ config:
     ez-specificity:
       env:
         - name: MINIO_SERVER
-          value: "http://mmli-backend-staging-minio.staging.svc.cluster.local:9000"
+          value: "mmli-backend-staging-minio.staging.svc.cluster.local:9000"
         - name: MMLI_BACKEND_HOST
-          value: "http://mmli-backend-staging.staging.svc.cluster.local:8080"
+          value: "mmli-backend-staging.staging.svc.cluster.local:8080"
     ezspec-unidock:
       runtimeClassName: nvidia
       nodeSelector:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,6 +4,9 @@ ingress:
   tls: false
   annotations: {}
 
+service:
+  type: ClusterIP
+
 # Custom ingress configuration for only /chemscraper/analyze endpoint
 analyzeIngress:
   hostname: mmli.fastapi.localhost
@@ -12,6 +15,7 @@ analyzeIngress:
 
 controller:
   image: moleculemaker/mmli-backend:latest
+  imagePullPolicy: Always
 
 sharedStorage:
   existingClaim: mmli-shared-job-data
@@ -484,6 +488,53 @@ config:
         runAsGroup: 0
         # fsGroup: 202
 
+    # TODO: update to use correct image later
+    test1:
+      # Example job image name + command combo
+      image: "ubuntu:jammy"
+      command: "echo '1' > ${JOB_OUTPUT_DIR}/step1.out"
+
+    # TODO: update to use correct image later
+    test2:
+      # Example job image name + command combo
+      image: "ubuntu:jammy"
+      command: "echo $(($(cat /uws/jobs/test1/${JOB_ID}/out/step1.out) * 5)) > ${JOB_OUTPUT_DIR}/step2.out"
+      initContainers:
+        - name: wait-for-test1
+          image: minio/mc
+          command: [ "/bin/bash", "-c" ]
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mmli-backend-secrets
+                  key: MINIO_ACCESS_KEY
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mmli-backend-secrets
+                  key: MINIO_SECRET_KEY
+          args:
+            - |
+              set -x
+              set -e
+              export SLEEP_DELAY=30
+              export MINIO_FILE_PATH=test1/${JOB_ID}/out/step1.out;
+              
+              # Loop until 'mc ls' finds the file (returns exit code 0)
+              mc alias set mmli2 http://${MINIO_SERVER} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY};
+              echo "Waiting for ${MINIO_FILE_PATH}...";
+              until mc ls "mmli2/$MINIO_FILE_PATH" 2>&1; do
+                echo "File not found. Retrying in ${SLEEP_DELAY} seconds...";
+                sleep ${SLEEP_DELAY};
+              done;
+  
+              echo "File detected! Preparing inputs...";
+              # TODO: Download files needed for next steps
+              # TODO: Validation / filtering / mapping to valid inputs
+  
+              echo "Inputs ready: Init container completed successful!";
+              exit 0
   external:
     chemscraper:
       apiBaseUrl: "https://chemscraper.backend.staging.mmli2.ncsa.illinois.edu"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -494,7 +494,7 @@ config:
 
     ez-specificity:
       # Example job image name + command combo
-      image: "moleculemaker/mmli-backend:coord-jobs"
+      image: "moleculemaker/mmli-backend:latest"
       command: "python ./coordinator.py"
       steps:
         # Define names / order for steps here

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -71,6 +71,7 @@ config:
   # TODO: Default these to local cluster? For now, default is staging and we override for prod
   chemscraper_url: "http://chemscraper-services-staging.staging.svc.cluster.local:8000"
   chemscraper_frontend_url: "https://chemscraper.frontend.staging.mmli2.ncsa.illinois.edu"
+  ezspecificity_frontend_url: "https://ezspecificity.frontend.staging.mmli2.ncsa.illinois.edu"
   novostoic_frontend_url: "https://novostoic.frontend.staging.mmli2.ncsa.illinois.edu"
   somn_frontend_url: "https://somn.frontend.staging.mmli2.ncsa.illinois.edu"
   clean_frontend_url: "https://clean.frontend.staging.mmli2.ncsa.illinois.edu"
@@ -492,81 +493,33 @@ config:
 
     # TODO: update to use correct image later
     ez-specificity:
-      # Kubeconfig (credentials + cluster) used to run this job in Kubernetes
-      kubeconfig: "/opt/kubeconfig"
-      # Namespace where this job should run
-      namespace: "mmli"
-
       # Example job image name + command combo
-      image: "perl:5.34.0"
-      command: "perl -Mbignum=bpi -wle 'print bpi(2000)' > ${JOB_OUTPUT_DIR}/pi.out"
-
-      ## Server working directory to store generated job data
-      workingVolume:
-        claimName: "mmli-shared-job-data"
-        mountPath: "/uws"
-        subPath: "uws"
-      ## Central data volumes to be mounted in job containers
-      volumes: []
-
-      ## Abort jobs after 3 days regardless of their behavior
-      activeDeadlineSeconds: 259200
-      ## Cleanup completed/failed jobs after 12 hours
-      ttlSecondsAfterFinished: 43200
-      ## Poll the log file for changes every `logFilePollingPeriod` seconds
-      logFilePollingPeriod: 300
-      securityContext:
-        runAsUser: 0
-        runAsGroup: 0
-        # fsGroup: 202
+      image: "moleculemaker/mmli-backend:coord-jobs"
+      command: "python ./coordinator.py"
+      steps:
+        # Define names / order for steps here
+        - ezspec-unidock
+        - ezspec-inference
+      resources:
+        limits:
+          cpu: "2"
+          memory: "4Gi"
+        requests:
+          cpu: "1"
+          memory: "2Gi"
 
     # TODO: update to use correct image later
-    test1:
+    ezspec-unidock:
       # Example job image name + command combo
       image: "ubuntu:jammy"
-      command: "echo '1' > ${JOB_OUTPUT_DIR}/step1.out"
+      command: "echo 5 > ${JOB_OUTPUT_DIR}/step1.out"
 
     # TODO: update to use correct image later
-    test2:
+    ezspec-inference:
       # Example job image name + command combo
       image: "ubuntu:jammy"
-      command: "echo $(($(cat /uws/jobs/test1/${JOB_ID}/out/step1.out) * 5)) > ${JOB_OUTPUT_DIR}/step2.out"
-      initContainers:
-        - name: wait-for-test1
-          image: minio/mc
-          command: [ "/bin/bash", "-c" ]
-          env:
-            - name: MINIO_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: mmli-backend-secrets
-                  key: MINIO_ACCESS_KEY
-            - name: MINIO_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: mmli-backend-secrets
-                  key: MINIO_SECRET_KEY
-          args:
-            - |
-              set -x
-              set -e
-              export SLEEP_DELAY=30
-              export MINIO_FILE_PATH=test1/${JOB_ID}/out/step1.out;
-              
-              # Loop until 'mc ls' finds the file (returns exit code 0)
-              mc alias set mmli2 http://${MINIO_SERVER} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY};
-              echo "Waiting for ${MINIO_FILE_PATH}...";
-              until mc ls "mmli2/$MINIO_FILE_PATH" 2>&1; do
-                echo "File not found. Retrying in ${SLEEP_DELAY} seconds...";
-                sleep ${SLEEP_DELAY};
-              done;
-  
-              echo "File detected! Preparing inputs...";
-              # TODO: Download files needed for next steps
-              # TODO: Validation / filtering / mapping to valid inputs
-  
-              echo "Inputs ready: Init container completed successful!";
-              exit 0
+      command: "echo 10 > ${JOB_OUTPUT_DIR}/step2.out"
+
   external:
     chemscraper:
       apiBaseUrl: "https://chemscraper.backend.staging.mmli2.ncsa.illinois.edu"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -491,7 +491,7 @@ config:
           cpu: "1"
           memory: "12Gi"
 
-    # TODO: update to use correct image later
+
     ez-specificity:
       # Example job image name + command combo
       image: "moleculemaker/mmli-backend:coord-jobs"
@@ -500,25 +500,55 @@ config:
         # Define names / order for steps here
         - ezspec-unidock
         - ezspec-inference
+
+      # Parent job doesn't need many resources
       resources:
         limits:
           cpu: "2"
-          memory: "4Gi"
+          memory: "2Gi"
         requests:
           cpu: "1"
-          memory: "2Gi"
+          memory: "1Gi"
 
-    # TODO: update to use correct image later
+
     ezspec-unidock:
-      # Example job image name + command combo
-      image: "ubuntu:jammy"
-      command: "echo 5 > ${JOB_OUTPUT_DIR}/step1.out"
+      image: moleculemaker/ezspec-unidock:latest
+      #command: "echo 5 > ${JOB_OUTPUT_DIR}/step1.out"
+      imagePullPolicy: Always
+      env:
+        - name: NVIDIA_DRIVER_CAPABILITIES
+          value: compute,utility
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: all
+      volumes:
+        - name: shared-storage
+          mountPath: /uws/jobs/ezspec-unidock/JOB_ID/in
+          subPath: uws/jobs/ezspec-unidock/JOB_ID/in
+          claimName: mmli-shared-job-data
+        - name: shared-storage
+          mountPath: /uws/jobs/ezspec-unidock/JOB_ID/out
+          subPath: uws/jobs/ezspec-unidock/JOB_ID/out
+          claimName: mmli-shared-job-data
 
-    # TODO: update to use correct image later
+
     ezspec-inference:
-      # Example job image name + command combo
-      image: "ubuntu:jammy"
-      command: "echo 10 > ${JOB_OUTPUT_DIR}/step2.out"
+      image: moleculemaker/ezspec-inference:latest
+      imagePullPolicy: Always
+      env:
+        - name: NVIDIA_DRIVER_CAPABILITIES
+          value: compute,utility
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: all
+      #command: "echo 10 > ${JOB_OUTPUT_DIR}/step2.out"
+      volumes:
+        - name: shared-storage
+          mountPath: /uws/jobs/ezspec-inference/JOB_ID/in
+          subPath: uws/jobs/ezspec-inference/JOB_ID/in
+          claimName: mmli-shared-job-data
+        - name: shared-storage
+          mountPath: /uws/jobs/ezspec-inference/JOB_ID/out
+          subPath: uws/jobs/ezspec-inference/JOB_ID/out
+          claimName: mmli-shared-job-data
 
   external:
     chemscraper:


### PR DESCRIPTION
## Problem
EZspecificity requires running multiple different processes that each depend on the output of the previous step.

## Approach
First-Pass:
* feat: support `initContainers` in job config - this could be a way to allow us to chain these jobs together

Considerations:
* This will require **a lot** more testing.
* Local cluster too small to run 2 concurrent containers - note that once initContainers are running the Pod has been scheduled and all of its resources have been allocated. This may be problematic given our pattern of needing to give too many resources to each job container
* Very finicky syntax / indentation - we're passing YAML thru a ConfigMap thru Python into a Jinja template to come out as YAML again that Kubernetes needs to be able to validate and read... The possibility of errors exists and will persist
* Not easy to pass configuration around - requires adjustments to existing `mmli-backend-secrets` because we can't pass in a key from a file in a ConfigMap as an envvar. But we CAN pass a key from a ConfigMap that isn't part of a file. So we need to take the keys that currently live in `mmli-backend-secrets -> secret.yaml` and move/copy these keys to the top level. Ideally the existing `mmli-backend` code can adjust to this pattern so that we can remove the duplicate keys altogether

Alternatives:
* ❌  It may be possible to build all of these processes into a single container image, but that might be unwieldy or too large, if not impossible (if the architecture / required tooling / versions differs too drastically)
* ❌ The frontend could coordinate these requests instead. For example, run job A & wait for complete, fetch output from job A & use it to run job B, etc
* ✅ Create `coordinator.py` for a lightweight Docker container that can be the best of both worlds

Second-Pass:
 * feat: added `coordinator.py` to handle running subjobs for some more complex parent jobs (e.g. `ez-specificity`)

Considerations:
* Cannot use same `job_id` as parent job - since job_id is our primary key, we would need to convert to a composite primary key (e.g. two primary keys `job_type` + `job_id`). 
* Instead of matching the parent `job_id`, we generate all unique `subjob_id` values on the initial submit and return them to the requester. We then use those same `subjob_id` values throughout the `coordinator.py` script :+1: this unfortunately does muddy the waters a 

TODOs (?):
- [x] bring back / make sure i didnt break any bits by accidentally modifying placeholder `ez-specificity` configuration
- [x] morph test1 -> unidock
- [x] morph test2 -> inference
- [x] ~~adjust staging/prod SealedSecrets for `mmli-backend-secrets`, copy keys from file to top-level~~ only needed for `initContainers` approach - skipping this for now, since we're going a different way

## How to Test
1. Checkout and run this branch locally
2. Enable Kubernetes in Docker Desktop
3. Deploy the Helm chart:
    * If you need to rerun this step using the same image, make sure to manually delete the Pod to ensure you're using the latest image
```bash
helm upgrade --install mmli-backend chart/ \
                  -f chart/values.local.yaml \
                  --namespace mmli \
                  --create-namespace \
                  --set controller.image=moleculemaker/mmli-backend:coord-jobs

# needed on subsequent runs:
sleep 15s && kubectl delete pods -n mmli -l app=mmli-fastapi
```
4. Submit a new `ez-specificity` job
    * This will create a new Job w/ `job_type=ez-specificity` that will run all subjobs
    * You should see that all job/subjob IDs are returned here, to allow you to track the jobs and locate their outputs
```bash
curl -XPOST localhost:8080/ez-specificity/jobs
```
5. Watch `kubectl get pods -n mmli -w` to see the jobs steps complete in sequence
6. You should see an `ezspec-unidock` subjob is created
    * Wait for this subjob to complete - this job simply prints the value `5` to a file
7. You should see an `ezspec-inference` subjob is created
    * Wait for this subjob to complete - this job simply prints the value `10` to a file
8. Check MinIO for output
    * You should see individual subjobs have their own bucket with their own output files
    * You should see that the top-level ez-specificity job also contains all of the output files for each step (by subjob_id) - maybe this could use `subjob_type` instead?

This is a very simple proof-of-concept for this pattern, which I'm still not fully convinced is a good option... 🤔 