### PR TITLE
feat(ez-specificity): validate inputs and write job_config.json in parent handler

### DIFF
--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -29,11 +29,16 @@ from services import kubejob_service
 from services.clean_service import CleanService
 from services.molli_service import MolliService
 from services.minio_service import MinIOService
+from services.shared import is_valid_pdb_file
 from services.somn_service import SomnService
 
 router = APIRouter()
 
 log = get_logger(__name__)
+
+# EZSpecificity input limits (mirror the frontend's MAX_ENZYMES / substrate cap)
+EZSPEC_MAX_ENZYMES = 5
+EZSPEC_MAX_SUBSTRATES = 10
 
 
 @router.post("/{job_type}/jobs", response_model=Job, tags=['Jobs'], description="Create a new run for a new or existing Job")
@@ -330,9 +335,56 @@ async def create_job(
 
         # EZspecificity parent job, see subjobs below
         elif job_type == JobType.EZ_SPECIFICITY:
-            # TODO: update command to handle ez-specificity jobs
             command = app_config['kubernetes_jobs'][job_type]['command']
             job_config = json.loads(job_info.replace('\"', '"'))
+
+            # Validate user input: we need enzymes + substrates to build the docking config
+            if 'enzymes' not in job_config or 'substrates' not in job_config:
+                raise HTTPException(status_code=400,
+                    detail='"job_info" requires "enzymes" and "substrates"')
+
+            enzymes = job_config['enzymes']
+            substrates = job_config['substrates']
+            if not isinstance(enzymes, list) or not isinstance(substrates, list):
+                raise HTTPException(status_code=400,
+                    detail='"enzymes" and "substrates" must be lists')
+            if not 1 <= len(enzymes) <= EZSPEC_MAX_ENZYMES:
+                raise HTTPException(status_code=400,
+                    detail=f'Expected 1-{EZSPEC_MAX_ENZYMES} enzyme(s), got {len(enzymes)}')
+            if not 1 <= len(substrates) <= EZSPEC_MAX_SUBSTRATES:
+                raise HTTPException(status_code=400,
+                    detail=f'Expected 1-{EZSPEC_MAX_SUBSTRATES} substrate(s), got {len(substrates)}')
+
+            # Validate each uploaded enzyme structure. The PDBs were already uploaded
+            # to {job_id}/in/ via the /upload endpoint; we re-check them here (server-side,
+            # where we can actually parse the file content) before kicking off the pipeline.
+            for enzyme in enzymes:
+                filename = enzyme.get('filename')
+                if not filename:
+                    raise HTTPException(status_code=400, detail='Each enzyme requires a "filename"')
+                content = service.get_file(job_type, f"{job_id}/in/{filename}")
+                if content is None:
+                    raise HTTPException(status_code=400,
+                        detail=f'Enzyme structure not found in uploads: {filename}')
+                if not is_valid_pdb_file(content):
+                    raise HTTPException(status_code=400,
+                        detail=f'Invalid PDB structure: {filename}')
+
+            # Write job_config.json into the parent job's input dir. coordinator.py copies
+            # the parent's in/ into each subjob, so unidock + inference both receive this
+            # config (the containers read job_config.json, not the job_info API field).
+            container_config = {
+                'enzymes': enzymes,
+                'substrates': substrates,
+            }
+            if 'docking' in job_config:
+                container_config['docking'] = job_config['docking']
+            if service.ensure_bucket_exists(job_type):
+                service.upload_file(
+                    job_type,
+                    f"{job_id}/in/job_config.json",
+                    json.dumps(container_config).encode('utf-8'),
+                )
 
             # Generate subjob_ids, store these in job_info / pass along as environment
             ezspec_unidock_job_id = str(kubejob_service.generate_uuid())

--- a/app/services/shared.py
+++ b/app/services/shared.py
@@ -79,9 +79,13 @@ def get_iupac_name(smiles: str) -> str:
         return None
     
     
-def is_valid_pdb_file(file_content: bytes) -> bool:
+def is_valid_pdb_file(file_content) -> bool:
     try:
+        # RDKit's MolFromPDBBlock expects the PDB block as text; callers may pass
+        # raw bytes (e.g. from an upload or MinIO), so decode to str first.
+        if isinstance(file_content, (bytes, bytearray)):
+            file_content = file_content.decode('utf-8', errors='ignore')
         mol = Chem.MolFromPDBBlock(file_content)
         return mol is not None
-    except Exception as e:
+    except Exception:
         return False


### PR DESCRIPTION
## Summary

Implements `job_config.json` generation + input validation for the `ez-specificity` parent job, so the unidock → inference chain (driven by `coordinator.py`) actually receives its config.

## Why

The `ez-specificity` parent job runs `coordinator.py`, which copies the parent's `in/` files into each subjob (`ezspec-unidock`, `ezspec-inference`). The parent handler never wrote `job_config.json`, so the subjob containers — which read `job_config.json` from `in/` — got no config and failed. (Observed in MinIO: only the uploaded PDB was present in `ez-specificity/<job_id>/in/`, no `job_config.json`.)

This logic belongs server-side (not in the frontend) so we can validate the uploaded input files before kicking off the pipeline.

## What changed

**`app/routers/job.py`** — `EZ_SPECIFICITY` handler:
- Validate `job_info` has `enzymes` and `substrates` (400 if missing / not lists)
- Validate counts: **1–5 enzymes, 1–10 substrates** (mirrors the frontend's `MAX_ENZYMES = 5` and substrate cap of 10; named constants `EZSPEC_MAX_ENZYMES` / `EZSPEC_MAX_SUBSTRATES`)
- Validate each uploaded enzyme structure server-side via `is_valid_pdb_file` — fetch `{job_id}/in/{filename}` from MinIO and parse it (400 if missing/invalid). This catches the UniProt/AlphaFold-fetched PDBs the frontend never validates.
- Write `job_config.json` (`enzymes`/`substrates` [+ `docking`]) to `{job_id}/in/` so `coordinator.py` propagates it to both subjobs

**`app/services/shared.py`**:
- Harden `is_valid_pdb_file` to accept `bytes` or `str` (RDKit's `MolFromPDBBlock` expects `str`; both this new caller and the existing `/pdb/validate` route pass bytes)

## Test plan

- [x] `py_compile` passes for both files
- [x] Logic traced against `coordinator.py`'s copy-to-subjob flow
- [ ] **Not yet run end-to-end** (no MinIO/k8s/RDKit available locally). Needs: deploy this branch → submit an ez-specificity job from the frontend → confirm `job_config.json` lands in `ez-specificity/<job_id>/in/` and is copied into both subjobs → unidock + inference run
- [ ] Verify 400 responses for: missing `enzymes`/`substrates`, > 5 enzymes, > 10 substrates, invalid/missing PDB

## Notes

Branched off `lambert8/feature/support-init-containers-for-chaining-jobs`, so this PR targets that branch (not `main`).
