### PR TITLE
chore: upgrade kubernetes client to 34.1.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Docker meta
         id: meta

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ python-dotenv==1.0.1
 minio==7.1.17
 rdkit==2023.3.3
 requests==2.31.0
-kubernetes==31.0.0
+kubernetes==34.1.0
 
 # For ReactionMiner
 python-terrier==0.13.0


### PR DESCRIPTION
## Problem
The `mmli-backend` container runs a KubeWatcher thread that constantly polls for job status updates

Sometimes the thread seems to disconnect, and status updates are missed as a result. The API reports jobs as `queued` when they run into this error, even though the associated K8S job has `Completed` successfully. Coordinator jobs can stall because of the missed updates, sine they are polling for the status that was missed.

## Approach
* chore: consult [Compatibility Matrix](https://github.com/kubernetes-client/python#compatibility) to find ideal version for k8s `v1.34.6+k3s1`
    * Found `34.x.y` matches this version
    * Tracked this to [Stable Release 34.1.0](https://github.com/kubernetes-client/python/releases/tag/v34.1.0)
    * Used this `34.1.0` semver as new client version :+1:

## How to Test
1. Deploy this to mmli-backend-staging
2. Run a job, wait for errors, wait a few days, etc
    * Take note of any odd behavior or errors in the logs
    * I'm still trying to find a migration/upgrade guide, but have not had luck yet