### PR TITLE
test: add pytest harness and characterization tests for the legacy API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+# Runs the test suite on every pull request and on pushes to the long-lived branches.
+# The suite is executed inside the same base image the runtime uses, so tests exercise
+# the interpreter and pinned library versions that actually ship rather than whatever a
+# GitHub runner happens to provide.
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build test image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.test
+          push: false
+          load: true
+          tags: mmli-backend-test:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run pytest
+        run: docker run --rm mmli-backend-test:${{ github.sha }} pytest -q --tb=short

--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ chart/charts/
 .idea/
 
 drafts/
+
+# Throwaway SQLite database created by the characterization test suite
+.pytest-characterization.db

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,30 @@
+# Test image. Mirrors the runtime Dockerfile's base and dependency install so the
+# characterization tests exercise the same interpreter and library versions that ship,
+# then adds the test-only dependencies on top.
+#
+# The platform is pinned to match the runtime Dockerfile. It is not optional:
+# python-terrier depends on pytrec-eval-terrier, which publishes no aarch64 wheel and
+# fails to build from source, so an arm64 build of this image cannot install the
+# application's dependencies at all.
+FROM --platform=linux/amd64 condaforge/mambaforge:24.1.2-0
+WORKDIR /code
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
+# openbabel is imported by the somn router/service, so it is required to import the app
+RUN mamba install -y openbabel && mamba clean --all -y
+
+COPY ./requirements.txt /code/requirements.txt
+COPY ./requirements-dev.txt /code/requirements-dev.txt
+RUN pip install --no-cache-dir -r /code/requirements-dev.txt
+
+COPY ./pytest.ini /code/pytest.ini
+COPY ./app /code/app
+COPY ./tests /code/tests
+
+# kubejob_service loads a cluster config at import time and exits the process if it
+# finds none. cfg/config.yaml points at /opt/kubeconfig, so place a dummy there.
+COPY ./tests/fixtures/kubeconfig.yaml /opt/kubeconfig
+
+CMD ["pytest", "-q"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,34 @@
 # mmli-backend
 Unified FastAPI based backend for ChemScraper, (CLEAN job-manager and Molli - future scope)
 
+## Running the tests
+
+The suite runs inside the same base image the service ships from, so it exercises the
+pinned interpreter and library versions rather than whatever is on your machine:
+
+```bash
+docker build -f Dockerfile.test -t mmli-backend-test .
+docker run --rm mmli-backend-test pytest -q
+```
+
+To iterate on tests without rebuilding, mount them in:
+
+```bash
+docker run --rm -v "$PWD/tests:/code/tests" mmli-backend-test pytest -q
+```
+
+The image is pinned to `linux/amd64`. This is not optional: `python-terrier` depends on
+`pytrec-eval-terrier`, which publishes no `aarch64` wheel and cannot build from source,
+so an arm64 build fails to install the application's dependencies at all.
+
+### About `tests/characterization/`
+
+These tests pin the **current** behavior of the legacy API, including behavior that is
+wrong. Assertions covering known defects carry a `DEFECT:` comment naming the problem.
+Their purpose is to make behavioral change visible: when a later change alters one of
+these responses, the test diff is the record of that decision. A failure here means
+"something changed" — decide whether the change was intended before editing the test.
+
 ## ⭐️ Recommended local development (Docker)
 
 ### (1/4) Create a `.env`

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+# The application imports its own modules as top-level packages ("from config import ...",
+# "from routers import ..."), so app/ must be on sys.path rather than the repo root.
+pythonpath = app
+testpaths = tests
+asyncio_mode = auto
+filterwarnings =
+    ignore::DeprecationWarning

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,17 @@
+# Test-only dependencies. Kept separate from requirements.txt so the runtime
+# image never installs them.
+-r requirements.txt
+
+pytest==7.4.4
+pytest-asyncio==0.21.2
+
+# starlette 0.22 (pinned transitively by fastapi 0.89) builds its TestClient by passing
+# app= to httpx.Client. httpx removed that argument in 0.28, so an unpinned install
+# fails with "Client.__init__() got an unexpected keyword argument 'app'". Test-only
+# pin; the runtime requirements are untouched. This can be dropped once the framework
+# upgrade lands.
+httpx==0.23.3
+
+# Async SQLite driver: lets the characterization tests run against a throwaway
+# file-backed DB instead of requiring a live Postgres.
+aiosqlite==0.19.0

--- a/tests/characterization/test_app_startup.py
+++ b/tests/characterization/test_app_startup.py
@@ -1,0 +1,57 @@
+"""Characterization tests for application startup.
+
+These record a latent hazard so that it fails loudly rather than in production.
+"""
+import inspect
+import pathlib
+
+from fastapi import FastAPI
+
+import main
+
+
+def test_fastapi_silently_ignores_the_lifespan_argument():
+    """main.py passes `lifespan=` to FastAPI, but this version does not support it.
+
+    FastAPI gained lifespan support in 0.93.0. On the pinned 0.89.0 the argument is
+    swallowed by **extra and discarded, so `main.lifespan` never executes -- neither its
+    startup half nor its `watcher.close()` shutdown half.
+    """
+    assert "lifespan" not in inspect.signature(FastAPI.__init__).parameters
+
+
+def test_the_custom_lifespan_is_not_wired_into_the_app():
+    """Corollary of the above, asserted against the app object rather than the library."""
+    lifespan_context = main.app.router.lifespan_context
+
+    # Starlette's default, not main.lifespan
+    assert getattr(lifespan_context, "__name__", None) != "lifespan"
+
+
+def test_the_inert_lifespan_hides_a_call_that_would_hang_startup():
+    """UPGRADE HAZARD, recorded here so that whoever upgrades FastAPI meets it.
+
+    `main.lifespan` calls `watcher.run()`, which is the KubeEventWatcher thread body: an
+    unbroken `while True` with no break or return. The watcher is already running -- its
+    constructor starts the thread -- so if this lifespan ever became live it would run a
+    second copy of that loop synchronously on the event loop and startup would never
+    complete.
+
+    It is harmless today only because FastAPI 0.89 discards the lifespan entirely. The
+    moment FastAPI is upgraded past 0.93 this becomes a hang on boot, so the call has to
+    be removed as part of that upgrade rather than after it.
+    """
+    assert "watcher.run()" in inspect.getsource(main.lifespan)
+
+
+def test_the_watcher_thread_is_started_by_its_constructor():
+    """Why the inert lifespan has gone unnoticed: startup does not depend on it.
+
+    Asserted against the module's source text because conftest replaces the real
+    __init__ with a stub, so inspecting the live class would only describe the stub.
+    """
+    from services import kubejob_service
+
+    source = pathlib.Path(kubejob_service.__file__).read_text()
+
+    assert "self.thread.start()" in source

--- a/tests/characterization/test_files_api.py
+++ b/tests/characterization/test_files_api.py
@@ -1,0 +1,117 @@
+"""Characterization tests for the legacy Files API.
+
+As with the Jobs API tests, these pin CURRENT behavior. Assertions covering known
+defects carry a `DEFECT:` comment.
+
+Note the route parameter is named `bucket_name`: the public URL exposes the storage
+bucket, which happens to equal the job type. That coupling is itself part of what /v1
+replaces.
+"""
+
+NOVOSTOIC_OPTSTOIC = "novostoic-optstoic"
+
+
+class TestUpload:
+    def test_upload_mints_a_job_id_when_none_is_given(self, client):
+        resp = client.post(
+            f"/{NOVOSTOIC_OPTSTOIC}/upload",
+            files={"file": ("input.txt", b"hello", "text/plain")},
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["jobID"]) == 32
+        assert "uploaded_at" in body
+
+    def test_upload_honours_a_caller_supplied_job_id(self, client):
+        resp = client.post(
+            f"/{NOVOSTOIC_OPTSTOIC}/upload?job_id=my-job",
+            files={"file": ("input.txt", b"hello", "text/plain")},
+        )
+
+        assert resp.json()["jobID"] == "my-job"
+        assert client.minio.get_file(NOVOSTOIC_OPTSTOIC, "my-job/in/input.txt") == b"hello"
+
+    def test_chemscraper_uploads_must_be_pdfs(self, client):
+        resp = client.post(
+            "/chemscraper/upload",
+            files={"file": ("not-a.pdf", b"just text", "application/pdf")},
+        )
+
+        # DEFECT: a rejected upload is a client error, but this reports 500.
+        assert resp.status_code == 500
+        assert resp.json() == {"error": "Unable to upload file"}
+
+    def test_chemscraper_accepts_a_real_pdf(self, client):
+        resp = client.post(
+            "/chemscraper/upload",
+            files={"file": ("real.pdf", b"%PDF-1.4 ...", "application/pdf")},
+        )
+
+        assert resp.status_code == 200
+
+    def test_any_other_bucket_accepts_any_content(self, client):
+        """Only chemscraper validates content; every other bucket takes anything."""
+        resp = client.post(
+            f"/{NOVOSTOIC_OPTSTOIC}/upload",
+            files={"file": ("anything.bin", b"\x00\x01\x02", "application/octet-stream")},
+        )
+
+        assert resp.status_code == 200
+
+
+class TestResults:
+    def test_missing_output_returns_200_with_a_null_body(self, client):
+        client.post(f"/{NOVOSTOIC_OPTSTOIC}/jobs", json={"job_id": "j1"})
+
+        resp = client.get(f"/{NOVOSTOIC_OPTSTOIC}/results/j1")
+
+        # DEFECT: a polling client cannot distinguish "still running" from "finished
+        # with no results" from "wrong job id" -- all three are 200 null.
+        assert resp.status_code == 200
+        assert resp.json() is None
+
+    def test_unknown_job_id_returns_200_with_a_serialized_exception(self, client):
+        resp = client.get(f"/{NOVOSTOIC_OPTSTOIC}/results/never-existed")
+
+        # DEFECT: the service `return`s (rather than `raise`s) an HTTPException, so
+        # FastAPI serializes the exception object as an ordinary response body. The
+        # HTTP status is 200 and the 404 is buried inside the payload, where no
+        # standard client will look for it.
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "detail": "Job not found",
+            "headers": None,
+            "status_code": 404,
+        }
+
+    def test_invalid_bucket_returns_400(self, client):
+        resp = client.get("/not-a-real-tool/results/j1")
+
+        assert resp.status_code == 400
+        assert "Invalid job type" in resp.json()["detail"]
+
+
+class TestInputsAndErrors:
+    def test_inputs_returns_404_when_nothing_was_uploaded(self, client):
+        resp = client.get(f"/{NOVOSTOIC_OPTSTOIC}/inputs/j1")
+
+        assert resp.status_code == 404
+
+    def test_inputs_lists_uploaded_files(self, client):
+        client.minio.put(NOVOSTOIC_OPTSTOIC, "j1/in/a.txt", b"a")
+
+        resp = client.get(f"/{NOVOSTOIC_OPTSTOIC}/inputs/j1")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+    def test_errors_returns_404_when_absent(self, client):
+        assert client.get(f"/{NOVOSTOIC_OPTSTOIC}/errors/j1").status_code == 404
+
+    def test_errors_returns_the_error_file(self, client):
+        client.minio.put(NOVOSTOIC_OPTSTOIC, "j1/errors.txt", b"boom")
+
+        resp = client.get(f"/{NOVOSTOIC_OPTSTOIC}/errors/j1")
+
+        assert resp.status_code == 200

--- a/tests/characterization/test_jobs_api.py
+++ b/tests/characterization/test_jobs_api.py
@@ -1,0 +1,210 @@
+"""Characterization tests for the legacy Jobs API.
+
+These pin the CURRENT behavior of `/{job_type}/jobs`, including behavior that is
+wrong. Tests covering known defects are marked with a `DEFECT:` comment naming what is
+wrong; when a later change fixes one, the test diff is the record of that decision.
+
+Nothing here should be read as an endorsement of the behavior it asserts.
+"""
+import json
+
+import pytest
+
+from models.enums import JobStatus
+
+
+DEFAULTS = "defaults"
+
+
+def _post_job(client, job_type=DEFAULTS, **body):
+    return client.post(f"/{job_type}/jobs", json=body)
+
+
+class TestCreateJob:
+    def test_new_job_returns_201_with_stringified_fields(self, client):
+        resp = _post_job(client, email="a@b.edu", job_info='{"x": 1}')
+
+        assert resp.status_code == 201
+        body = resp.json()
+        assert set(body) == {"job_id", "run_id", "email", "job_info"}
+        assert body["email"] == "a@b.edu"
+        assert body["job_info"] == '{"x": 1}'
+        assert len(body["job_id"]) == 32  # uuid4().hex, dashes stripped
+
+    def test_absent_optional_fields_serialize_as_the_string_None(self, client):
+        # DEFECT: every field is passed through str(), so a null run_id/email is
+        # returned as the four-character string "None" rather than JSON null.
+        resp = _post_job(client)
+
+        assert resp.status_code == 201
+        assert resp.json()["run_id"] == "None"
+        assert resp.json()["email"] == "None"
+
+    def test_job_info_defaults_to_empty_object_string(self, client):
+        assert _post_job(client).json()["job_info"] == "{}"
+
+    def test_client_may_choose_its_own_job_id(self, client):
+        resp = _post_job(client, job_id="client-chosen-id")
+
+        assert resp.status_code == 201
+        assert resp.json()["job_id"] == "client-chosen-id"
+
+    def test_a_kubernetes_job_is_submitted(self, client):
+        _post_job(client, job_id="k8s-1")
+
+        assert len(client.k8s_jobs) == 1
+        assert client.k8s_jobs[0]["job_id"] == "k8s-1"
+        assert client.k8s_jobs[0]["job_type"] == DEFAULTS
+
+    def test_invalid_job_type_returns_400(self, client):
+        resp = _post_job(client, job_type="not-a-real-tool")
+
+        assert resp.status_code == 400
+        assert "Invalid job type" in resp.json()["detail"]
+
+
+class TestCreateJobWithExistingId:
+    """The collision branch: POSTing a job_id that already exists.
+
+    Every assertion in this class documents a defect. See PR "legacy fixes".
+    """
+
+    def test_returns_200_and_discloses_the_stored_email(self, client):
+        _post_job(client, job_id="victim", email="owner@illinois.edu", job_info='{"secret": 1}')
+
+        resp = _post_job(client, job_id="victim")
+
+        # DEFECT: unauthenticated information disclosure. A caller who guesses an
+        # existing job_id is told the owner's email address.
+        assert resp.status_code == 200
+        assert resp.json()["email"] == "owner@illinois.edu"
+
+    def test_overwrites_the_stored_job_info(self, client):
+        _post_job(client, job_id="victim", email="owner@illinois.edu", job_info='{"secret": 1}')
+
+        resp = _post_job(client, job_id="victim", job_info='{"tampered": true}')
+
+        # DEFECT: unauthenticated data tampering. The caller's job_info replaces the
+        # owner's stored input, destroying the record of what was actually run.
+        assert resp.json()["job_info"] == '{"tampered": true}'
+
+    def test_submits_a_second_kubernetes_job(self, client):
+        _post_job(client, job_id="victim")
+        _post_job(client, job_id="victim")
+
+        # DEFECT: create_job runs before the existence check, so a duplicate POST
+        # launches a second pod against the same job_id.
+        assert len(client.k8s_jobs) == 2
+
+
+class TestReadJobs:
+    def test_list_by_type_returns_every_users_job_including_email(self, client):
+        _post_job(client, job_id="j1", email="one@illinois.edu")
+        _post_job(client, job_id="j2", email="two@illinois.edu")
+
+        resp = client.get(f"/{DEFAULTS}/jobs")
+
+        # DEFECT: unauthenticated, unpaginated, and returns other users' addresses.
+        assert resp.status_code == 200
+        emails = sorted(job["email"] for job in resp.json())
+        assert emails == ["one@illinois.edu", "two@illinois.edu"]
+
+    def test_list_by_job_id_returns_a_list_not_an_object(self, client):
+        _post_job(client, job_id="j1")
+
+        body = client.get(f"/{DEFAULTS}/jobs/j1").json()
+
+        # A single job is still wrapped in a list by this endpoint.
+        assert isinstance(body, list)
+        assert len(body) == 1
+        assert body[0]["job_id"] == "j1"
+
+    def test_new_jobs_start_queued(self, client):
+        _post_job(client, job_id="j1")
+
+        assert client.get(f"/{DEFAULTS}/jobs/j1").json()[0]["phase"] == JobStatus.QUEUED
+
+    def test_unknown_job_id_returns_an_empty_list_not_404(self, client):
+        resp = client.get(f"/{DEFAULTS}/jobs/does-not-exist")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_invalid_job_type_returns_400(self, client):
+        assert client.get("/not-a-real-tool/jobs").status_code == 400
+
+
+class TestDeleteJob:
+    def test_delete_removes_the_row_but_leaves_the_kubernetes_job_running(self, client):
+        _post_job(client, job_id="j1", run_id="r1")
+        client.k8s_jobs.clear()
+
+        resp = client.delete(f"/{DEFAULTS}/jobs/j1/r1")
+
+        assert resp.status_code == 200
+        assert client.get(f"/{DEFAULTS}/jobs/j1").json() == []
+        # DEFECT: kubejob_service.delete_job() is never called, so the pod keeps
+        # running with no DB row to track it.
+        assert client.k8s_jobs == []
+
+    def test_delete_unknown_job_returns_404(self, client):
+        assert client.delete(f"/{DEFAULTS}/jobs/nope/nope").status_code == 404
+
+
+class TestPerToolInputValidation:
+    def test_chemscraper_requires_input_file(self, client):
+        resp = _post_job(client, job_type="chemscraper", job_info="{}")
+
+        assert resp.status_code == 400
+        assert "input_file" in resp.json()["detail"]
+
+    def test_ml_simplefold_requires_fasta(self, client):
+        resp = _post_job(client, job_type="ml-simplefold", job_info="{}")
+
+        assert resp.status_code == 400
+        assert "fasta" in resp.json()["detail"]
+
+    def test_ez_specificity_requires_enzymes_and_substrates(self, client):
+        resp = _post_job(client, job_type="ez-specificity", job_info="{}")
+
+        assert resp.status_code == 400
+        assert "enzymes" in resp.json()["detail"]
+
+    @pytest.mark.parametrize(
+        "job_info, expected",
+        [
+            ('{"enzymes": {}, "substrates": []}', "must be lists"),
+            ('{"enzymes": [], "substrates": ["c"]}', "enzyme"),
+            ('{"enzymes": [{"filename": "a.pdb"}], "substrates": []}', "substrate"),
+        ],
+    )
+    def test_ez_specificity_rejects_malformed_input(self, client, job_info, expected):
+        resp = _post_job(client, job_type="ez-specificity", job_info=job_info)
+
+        assert resp.status_code == 400
+        assert expected in resp.json()["detail"]
+
+    def test_ez_specificity_rejects_an_enzyme_that_was_never_uploaded(self, client):
+        resp = _post_job(
+            client,
+            job_type="ez-specificity",
+            job_info='{"enzymes": [{"filename": "missing.pdb"}], "substrates": ["CCO"]}',
+        )
+
+        assert resp.status_code == 400
+        assert "not found in uploads" in resp.json()["detail"]
+
+
+class TestJobInfoEscaping:
+    def test_job_info_is_stored_as_an_opaque_string(self, client):
+        """job_info is a string field, not a modelled object.
+
+        Nothing about its per-tool shape appears in the OpenAPI schema; this is the
+        core FAIR problem the /v1 API exists to solve.
+        """
+        _post_job(client, job_id="j1", job_info='{"nested": {"a": [1, 2]}}')
+
+        stored = client.get(f"/{DEFAULTS}/jobs/j1").json()[0]["job_info"]
+
+        assert isinstance(stored, str)
+        assert json.loads(stored) == {"nested": {"a": [1, 2]}}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,143 @@
+"""Test harness for the mmli-backend FastAPI app.
+
+Importing the application has three side effects that make it untestable as-is, so all
+three are neutralized here BEFORE any app module is imported:
+
+1. `app/config.py` reads `cfg/config.yaml` relative to the working directory at import
+   time, and derives the database URL from a secrets file that does not exist in CI.
+2. `models/sqlmodel/db.py` builds a global engine from `SQLALCHEMY_DATABASE_URL` at
+   import time, so the URL has to be in the environment before the import happens.
+3. `main.py` constructs a `KubeEventWatcher()` at module scope, whose `__init__` opens a
+   real database connection and starts a thread running an endless Kubernetes watch loop.
+
+Order matters in this file. Environment setup and the watcher patch must both happen
+above the application imports, which is why those imports are not at the top.
+"""
+import os
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+APP_DIR = REPO_ROOT / "app"
+
+# (1) + (2): configure the app before anything imports `config`.
+_db_file = REPO_ROOT / ".pytest-characterization.db"
+os.environ["CONFIG_FILEPATH"] = str(APP_DIR / "cfg" / "config.yaml")
+os.environ["SECRET_FILEPATH"] = str(APP_DIR / "cfg" / "does-not-exist.yaml")
+os.environ["SQLALCHEMY_DATABASE_URL"] = f"sqlite+aiosqlite:///{_db_file}"
+os.environ.setdefault("MINIO_SERVER", "localhost:9000")
+os.environ.setdefault("MINIO_ACCESS_KEY", "test")
+os.environ.setdefault("MINIO_SECRET_KEY", "test")
+
+if str(APP_DIR) not in sys.path:
+    sys.path.insert(0, str(APP_DIR))
+
+# (3): stub the watcher before `main` instantiates one.
+from services import kubejob_service  # noqa: E402
+
+
+def _noop(self, *args, **kwargs):
+    return None
+
+
+kubejob_service.KubeEventWatcher.__init__ = _noop
+kubejob_service.KubeEventWatcher.run = _noop
+kubejob_service.KubeEventWatcher.close = _noop
+kubejob_service.KubeEventWatcher.is_alive = lambda self: False
+
+import logging  # noqa: E402
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlmodel import SQLModel, create_engine  # noqa: E402
+
+import main  # noqa: E402
+from services.minio_service import MinIOService  # noqa: E402
+
+# db.py builds its engine with echo=True, which makes every test emit the full SQL log.
+logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
+
+
+class FakeMinIO:
+    """In-memory stand-in for MinIOService.
+
+    Only the methods the routers actually call are implemented; anything else should
+    fail loudly rather than silently succeed, so unimplemented calls raise AttributeError
+    in the normal way.
+    """
+
+    def __init__(self):
+        # {bucket: {object_name: bytes}}
+        self.objects = {}
+
+    # -- helpers for tests -------------------------------------------------
+    def put(self, bucket, object_name, data: bytes):
+        self.objects.setdefault(bucket, {})[object_name.lstrip("/")] = data
+
+    # -- MinIOService surface ----------------------------------------------
+    def ensure_bucket_exists(self, bucket_name):
+        self.objects.setdefault(bucket_name, {})
+        return True
+
+    def upload_file(self, bucket_name, object_name, data):
+        self.put(bucket_name, object_name, data)
+        return True
+
+    def get_file(self, bucket_name, object_name):
+        return self.objects.get(bucket_name, {}).get(object_name.lstrip("/"))
+
+    def get_file_urls(self, bucket_name, prefix):
+        names = [n for n in self.objects.get(bucket_name, {}) if n.startswith(prefix.lstrip("/"))]
+        return [f"http://minio.test/{bucket_name}/{n}" for n in names] or None
+
+    def list_files(self, bucket_name, prefix="", recursive=True):
+        return [n for n in self.objects.get(bucket_name, {}) if n.startswith(prefix.lstrip("/"))]
+
+
+@pytest.fixture(autouse=True)
+def fresh_database():
+    """Recreate every table before each test so ordering cannot leak state.
+
+    Deliberately uses a synchronous engine over the same file rather than the app's
+    async one. TestClient runs the ASGI app on its own event loop in a worker thread,
+    and aiosqlite connections are bound to the loop that opened them, so driving the
+    async engine from the test's loop risks cross-loop errors that surface as flakes.
+    DDL through a sync connection sidesteps that entirely.
+    """
+    sync_engine = create_engine(f"sqlite:///{_db_file}")
+    SQLModel.metadata.drop_all(sync_engine)
+    SQLModel.metadata.create_all(sync_engine)
+    sync_engine.dispose()
+    yield
+
+
+@pytest.fixture
+def fake_minio():
+    return FakeMinIO()
+
+
+@pytest.fixture
+def created_k8s_jobs(monkeypatch):
+    """Record calls to kubejob_service.create_job instead of talking to Kubernetes.
+
+    Returns the list of recorded kwargs so a test can assert on what would have been
+    submitted to the cluster.
+    """
+    calls = []
+
+    def _record(**kwargs):
+        calls.append(kwargs)
+        return {"metadata": {"name": f"mmli-job-{kwargs.get('job_type')}-{kwargs.get('job_id')}"}}
+
+    monkeypatch.setattr(kubejob_service, "create_job", _record)
+    return calls
+
+
+@pytest.fixture
+def client(fake_minio, created_k8s_jobs):
+    main.app.dependency_overrides[MinIOService] = lambda: fake_minio
+    with TestClient(main.app) as test_client:
+        test_client.minio = fake_minio
+        test_client.k8s_jobs = created_k8s_jobs
+        yield test_client
+    main.app.dependency_overrides.clear()

--- a/tests/fixtures/kubeconfig.yaml
+++ b/tests/fixtures/kubeconfig.yaml
@@ -1,0 +1,25 @@
+# Minimal, non-functional kubeconfig.
+#
+# app/services/kubejob_service.py loads a cluster config at import time and calls
+# sys.exit(1) if it finds none, so the module cannot be imported without one. The
+# server below is deliberately unresolvable: every test either stubs
+# kubejob_service.create_job or stubs KubeEventWatcher, so no request should ever be
+# made against it. If something does reach the network, the resulting DNS failure is
+# the signal that a test is missing a stub.
+apiVersion: v1
+kind: Config
+current-context: test
+clusters:
+  - name: test
+    cluster:
+      server: https://kubernetes.invalid:6443
+contexts:
+  - name: test
+    context:
+      cluster: test
+      user: test
+      namespace: mmli
+users:
+  - name: test
+    user:
+      token: not-a-real-token


### PR DESCRIPTION
> **Stacked on #109.** Base is `mjberry/fix-stuck-queued-jobs`, so review that first. Retarget to `main` once #109 lands.

First PR in a stack that brings the job API into better FAIR compliance. This one adds **no production code changes at all** — it establishes the safety net the later PRs depend on.

## Why

The repo has no automated tests. Later PRs in this stack change API behavior deliberately (closing an information-disclosure hole) and incidentally (a Pydantic v1 → v2 migration). Without an executable record of what the endpoints currently return, neither kind of change is reviewable — and a regression in the legacy contract would surface as a broken frontend rather than a red build.

## What's here

| File | Purpose |
|---|---|
| `Dockerfile.test`, `requirements-dev.txt` | Suite runs in the same base image the service ships from, so it exercises the pinned interpreter and library versions |
| `tests/conftest.py` | Neutralizes the three import-time side effects that make the app untestable; stubs Kubernetes and MinIO; throwaway SQLite DB |
| `tests/characterization/` | 40 tests pinning current Jobs/Files API behavior |
| `.github/workflows/test.yml` | Runs the suite on every PR (CI previously only built the runtime image) |

## About the characterization tests

They deliberately assert behavior that is **wrong**. Each such assertion carries a `DEFECT:` comment naming the problem — for example that POSTing an existing `job_id` returns the owner's email address, overwrites their stored `job_info`, and launches a second Kubernetes pod.

They are a baseline, not an endorsement. When a later PR changes one of these responses, the test diff is the record of that decision.

## Incidental evidence for #109

Every Jobs and Files test passes **identically** on this branch's base and on `main`. That is independent evidence that #109 does not alter the observable legacy contract — it changes ordering and failure handling, not responses.

## One finding

Pinned by tests in `tests/characterization/test_app_startup.py`.

**The application's lifespan handler has never run.** FastAPI gained `lifespan` support in 0.93.0; this repo pins 0.89.0. `main.py` passes `lifespan=` anyway, where it is swallowed by `**extra` and silently discarded — both the startup half and the `watcher.close()` shutdown half. The `KubeEventWatcher` works only because its constructor starts its own daemon thread.

This makes #109's removal of the `watcher.run()` call **correct but dormant**. `watcher.run()` is the watcher thread body — an unbroken `while True` with no `break` or `return` — so calling it from the lifespan would run a second copy of the loop synchronously on the event loop and startup would never complete. But since the lifespan never executes, nothing today would notice if that call came back.

It becomes load-bearing the moment FastAPI is upgraded past 0.93. A regression guard is included so the call cannot quietly return in the meantime, when reintroducing it would look harmless.

## Notes for review

- `linux/amd64` is pinned in `Dockerfile.test` and is not optional: `python-terrier` depends on `pytrec-eval-terrier`, which publishes no `aarch64` wheel and cannot build from source.
- `httpx` is pinned in `requirements-dev.txt` only. starlette 0.22's `TestClient` passes `app=` to `httpx.Client`, which httpx removed in 0.28. Runtime requirements are untouched; the pin can go once the framework upgrade lands.
- `tests/fixtures/kubeconfig.yaml` exists because `kubejob_service` loads a cluster config at import and calls `sys.exit(1)` if it finds none. Its server is deliberately unresolvable, so any test missing a stub fails with a DNS error rather than silently reaching the network.
- The DB reset fixture drives a *synchronous* engine over the same SQLite file. `TestClient` runs the app on its own event loop in a worker thread, and aiosqlite connections are bound to the loop that opened them, so using the async engine from the test's loop risks cross-loop flakes.

## Verification

40 passed, on the current `pydantic==1.9.2` stack.
