### PR TITLE
fix: close unauthenticated disclosure and tampering on duplicate job submission

### DIFF
--- a/app/routers/chemscraper.py
+++ b/app/routers/chemscraper.py
@@ -30,37 +30,42 @@ router = APIRouter()
 
 @router.post("/chemscraper/analyze", tags=['ChemScraper'], response_model=List[Molecule], deprecated=True)
 async def analyze_documents(requestBody: AnalyzeRequestBody, background_tasks: BackgroundTasks, service: MinIOService = Depends(), db: AsyncSession = Depends(get_session), email_service: EmailService = Depends()):
+    # An empty fileList or jobId used to fall out of the function with no return
+    # statement at all, which FastAPI renders as HTTP 200 with a null body - reporting
+    # success for a request that was never accepted and no job that will ever run.
+    if len(requestBody.fileList) == 0 or requestBody.jobId == "":
+        raise HTTPException(status_code=400, detail='"fileList" must be non-empty and "jobId" must be set')
+
     # Analyze only one document for NSF demo
-    if len(requestBody.fileList) > 0 and requestBody.jobId != "":
-        # Create a new job and add to the DB
-        separator = "|"
-        curr_time = time.time()
-        db_job: Job = await db.get(Job, requestBody.jobId)
-        if not db_job:
-            db_job = Job(
-                email=requestBody.user_email,
-                job_info=separator.join(requestBody.fileList),
-                job_id=requestBody.jobId,
-                phase=JobStatus.PROCESSING,
-                # Run ID takes the default value since the app doesn't support multiple runs right now
-                type=JobType.CHEMSCRAPER,
-                user_agent='',
-                time_created=int(curr_time)
-            )
+    # Create a new job and add to the DB
+    separator = "|"
+    curr_time = time.time()
+    db_job: Job = await db.get(Job, requestBody.jobId)
+    if not db_job:
+        db_job = Job(
+            email=requestBody.user_email,
+            job_info=separator.join(requestBody.fileList),
+            job_id=requestBody.jobId,
+            phase=JobStatus.PROCESSING,
+            # Run ID takes the default value since the app doesn't support multiple runs right now
+            type=JobType.CHEMSCRAPER,
+            user_agent='',
+            time_created=int(curr_time)
+        )
 
-        try: 
-            db.add(db_job)
-            await db.commit()
-        except Exception as e:
-            content = {"jobId": requestBody.jobId, "error_message": "Database Error Occurred.", "error_details": str(e)}
-            return JSONResponse(content=content, status_code=400) 
+    try:
+        db.add(db_job)
+        await db.commit()
+    except Exception as e:
+        content = {"jobId": requestBody.jobId, "error_message": "Database Error Occurred.", "error_details": str(e)}
+        return JSONResponse(content=content, status_code=400)
 
-        filename = requestBody.fileList[0]
-        chemscraperService = ChemScraperService(db=db)
-        objectPath = f"{requestBody.jobId}/in/{filename}"
-        background_tasks.add_task(chemscraperService.runChemscraperOnDocument, 'chemscraper', filename, objectPath, requestBody.jobId, service, email_service)
-        content = {"jobId": requestBody.jobId, "submitted_at": datetime.now().isoformat()}
-        return JSONResponse(content=content, status_code=status.HTTP_202_ACCEPTED)
+    filename = requestBody.fileList[0]
+    chemscraperService = ChemScraperService(db=db)
+    objectPath = f"{requestBody.jobId}/in/{filename}"
+    background_tasks.add_task(chemscraperService.runChemscraperOnDocument, 'chemscraper', filename, objectPath, requestBody.jobId, service, email_service)
+    content = {"jobId": requestBody.jobId, "submitted_at": datetime.now().isoformat()}
+    return JSONResponse(content=content, status_code=status.HTTP_202_ACCEPTED)
 
 
 @router.get("/chemscraper/similarity-sorted-order/{job_id}")

--- a/app/routers/job.py
+++ b/app/routers/job.py
@@ -20,7 +20,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from starlette import status
 from starlette.responses import JSONResponse
 
-from config import get_logger, app_config
+from config import get_logger, app_config, STATUS_ERROR
 from models.enums import JobType, JobStatus, JobTypes
 from models.sqlmodel.db import get_session
 from models.sqlmodel.models import Job, JobCreate, JobUpdate
@@ -41,6 +41,17 @@ log = get_logger(__name__)
 # EZSpecificity input limits (mirror the frontend's MAX_ENZYMES / substrate cap)
 EZSPEC_MAX_ENZYMES = 5
 EZSPEC_MAX_SUBSTRATES = 10
+
+
+async def _mark_job_failed(db: AsyncSession, db_job: Job) -> None:
+    """Move a just-created job to 'error' when nothing will ever run to advance it.
+
+    Only ever called for a row this request created. A job that already existed must
+    keep whatever phase it legitimately reached.
+    """
+    db_job.phase = JobStatus.ERROR
+    db.add(db_job)
+    await db.commit()
 
 
 CREATE_JOB_DESCRIPTION = """
@@ -463,10 +474,68 @@ async def create_job(
                 'value': somn_project_dir
             }]
 
+        # TODO: Set user_agent based on requestor
+        user_agent = ''
+
+        # Write the DB row BEFORE creating the Kubernetes Job. KubeWatcher looks this row
+        # up by jobId for every event it receives and drops events whose row does not
+        # exist yet; since the watch never replays old events, a Job that got created
+        # (and, for the short ones, finished) inside that window is stranded at 'queued'
+        # even after Kubernetes reports it complete.
+        #
+        # The same reordering exists on the open PR that fixes that stranding bug. It is
+        # repeated here rather than depended upon, because the duplicate-submission
+        # handling below needs the row to already exist and this branch does not build on
+        # that PR. Expect a small conflict if both land.
+        created_new_job = not db_job
+        if created_new_job:
+            db_job: Job = Job(
+                # User input
+                email=email,
+                job_info=job_info,
+                job_id=job_id,
+                run_id=run_id,
+
+                type=job_type,
+                command=command,
+                image=image_name,
+
+                # Job metadata
+                deleted=0,
+                time_created=int(time.time()),
+
+                # Set ser metadata
+                user_agent=user_agent,
+            )
+
+            db.add(db_job)
+            await db.commit()
+            await db.refresh(db_job)
+
+        # A POST naming a job_id that already exists is not a resubmission, and this
+        # endpoint has no authentication: the caller has proved only that they can name
+        # an id, which is not authority over the job that holds it. Stop here.
+        #
+        # Previously this path fell through and (a) launched a second Kubernetes Job
+        # under the same name, (b) replaced the stored job_info with the caller's, and
+        # (c) returned the owner's email address and inputs in the response body.
+        # The response keys and status code are unchanged so existing clients - notably
+        # coordinator.py, which reads job_id from a 200 or a 201 - keep working.
+        if not created_new_job:
+            log.warning(f'Ignoring duplicate job submission for existing job_id={job_id} (type={job_type})')
+            return JSONResponse(status_code=status.HTTP_200_OK, content={
+                'job_id': str(db_job.job_id),
+                'run_id': str(db_job.run_id),
+                # Withheld: naming an id is not authorisation to read its owner's
+                # address or the inputs they submitted.
+                'email': None,
+                'job_info': None,
+            })
+
         # Run a Kubernetes Job with the given image + command + environment
         try:
             log.debug(f"Creating Kubernetes job[{job_type}]: " + job_id)
-            kubejob_service.create_job(
+            create_response = kubejob_service.create_job(
                 job_type=job_type,
                 job_id=job_id,
                 run_id=run_id,
@@ -477,42 +546,21 @@ async def create_job(
         except Exception as ex:
             log.error("Failed to create Job: " + str(ex))
             log.error(traceback.format_exc())
+            # The row we just wrote is already visible to clients, and nothing will ever run
+            # to move it along - fail it here rather than leaving it polling 'queued' forever.
+            await _mark_job_failed(db, db_job)
             raise HTTPException(status_code=400, detail="Failed to create Job: " + str(ex))
 
-    else:
-        log.error("Failed to create job - invalid job type: " + str(job_type))
-        log.error(traceback.format_exc())
-        raise HTTPException(status_code=400, detail="Invalid job type: " + str(job_type))
-
-    # TODO: Set user_agent based on requestor
-    user_agent = ''
-
-    # TODO: Validation
-    # TODO: Set internal metadata / fields
-    if not db_job:
-        # Create a new DB job from user input
-        db_job: Job = Job(
-            # User input
-            email=email,
-            job_info=job_info,
-            job_id=job_id,
-            run_id=run_id,
-
-            type=job_type,
-            command=command,
-            image=image_name,
-
-            # Job metadata
-            deleted=0,
-            time_created=int(time.time()),
-
-            # Set ser metadata
-            user_agent=user_agent,
-        )
-
-        db.add(db_job)
-        await db.commit()
-        await db.refresh(db_job)
+        # create_job catches ApiException internally, logs it, and returns a response
+        # carrying status=error rather than propagating it. Kubernetes rejections -
+        # an exceeded quota, an unpullable image, a name that already exists - are
+        # therefore invisible to the except clause above. Without this check the caller
+        # is told 201 while the row sits at 'queued' forever with no pod behind it.
+        if isinstance(create_response, dict) and create_response.get('status') == STATUS_ERROR:
+            message = create_response.get('message', 'unknown error')
+            log.error(f'Kubernetes rejected job[{job_type}] {job_id}: {message}')
+            await _mark_job_failed(db, db_job)
+            raise HTTPException(status_code=400, detail="Failed to create Job: " + str(message))
 
         return JSONResponse(status_code=status.HTTP_201_CREATED, content={
             'job_id': str(db_job.job_id),
@@ -520,19 +568,10 @@ async def create_job(
             'email': str(db_job.email),
             'job_info': str(db_job.job_info),
         })
+
     else:
-        db_job.job_info = job_info
-
-        await db.merge(db_job)
-        await db.commit()
-        await db.refresh(db_job)
-
-    return JSONResponse(status_code=status.HTTP_200_OK, content={
-        'job_id': str(db_job.job_id),
-        'run_id': str(db_job.run_id),
-        'email': str(db_job.email),
-        'job_info': str(db_job.job_info),
-    })
+        log.error("Failed to create job - invalid job type: " + str(job_type))
+        raise HTTPException(status_code=400, detail="Invalid job type: " + str(job_type))
 
 
 @router.get("/{job_type}/jobs", tags=['Jobs'], description="Get a list of all job runs by type")
@@ -619,6 +658,20 @@ async def delete_job_by_type_and_job_id_and_run_id(job_type: str, job_id: str, r
     db_job = result.first()
     if not db_job:
         raise HTTPException(status_code=404, detail=f"Job does not exist with type={job_type} job_id={job_id} and run_id={run_id}")
+
+    # Delete the Kubernetes Job before dropping the row. Removing only the row leaves a
+    # pod running with nothing tracking it: KubeWatcher looks each event up by jobId and
+    # discards events whose row is gone, so the work continues, consumes cluster
+    # resources, and writes its output to MinIO with no way to observe or stop it.
+    #
+    # Deliberately best-effort. delete_job already swallows ApiException (a Job that
+    # Kubernetes has since reaped is a 404, which is the expected case for anything
+    # older than ttlSecondsAfterFinished), and a cluster problem must not leave the
+    # caller unable to delete their own record.
+    try:
+        kubejob_service.delete_job(job_type=job_type, job_id=job_id)
+    except Exception as ex:
+        log.error(f'Failed to delete Kubernetes job[{job_type}] {job_id}, deleting DB row anyway: {ex}')
 
     await db.execute(delete(Job).where(Job.type == job_type).where(Job.job_id == job_id).where(Job.run_id == run_id))
     await db.commit()

--- a/app/services/kubejob_service.py
+++ b/app/services/kubejob_service.py
@@ -490,9 +490,11 @@ def list_jobs(job_type=None, job_id=None):
     return response
 
 
-def delete_job(job_id: str) -> None:
+def delete_job(job_type: str, job_id: str) -> None:
+    # job_type is required: Kubernetes Job names are built from both parts, so calling
+    # this with only an id raised TypeError on every invocation. Nothing called it.
     namespace = get_namespace()
-    job_name = get_job_name_from_id(job_id)
+    job_name = get_job_name_from_id(job_type, job_id)
     # config_map_name = f'''{job_name}-positions'''
     body = client.V1DeleteOptions(propagation_policy='Background')
     api_response = None

--- a/app/services/novostoic_service.py
+++ b/app/services/novostoic_service.py
@@ -26,7 +26,7 @@ class NovostoicService:
     async def optstoicResultPostProcess(bucket_name: str, job_id: str, service: MinIOService, db: AsyncSession):
         job = await db.get(Job, job_id)
         if not job:
-            return HTTPException(status_code=404, detail="Job not found")
+            raise HTTPException(status_code=404, detail="Job not found")
         
         file = service.get_file(bucket_name, f"{job_id}/out/output.json")
         if not file:
@@ -59,7 +59,7 @@ class NovostoicService:
     async def novostoicResultPostProcess(bucket_name: str, job_id: str, service: MinIOService, db: AsyncSession):
         job = await db.get(Job, job_id)
         if not job:
-            return HTTPException(status_code=404, detail="Job not found")
+            raise HTTPException(status_code=404, detail="Job not found")
         
         file = service.get_file(bucket_name, f"{job_id}/out/output.json")
         if not file:

--- a/app/services/oed_service.py
+++ b/app/services/oed_service.py
@@ -21,7 +21,7 @@ class OEDService:
 
         job = await db.get(Job, job_id)
         if not job:
-            return HTTPException(status_code=404, detail="Job not found")
+            raise HTTPException(status_code=404, detail="Job not found")
         
         job_info = json.loads(job.job_info)
         data['query_smiles'] = {

--- a/tests/characterization/test_chemscraper_api.py
+++ b/tests/characterization/test_chemscraper_api.py
@@ -1,0 +1,60 @@
+"""Characterization tests for the deprecated ChemScraper analyze endpoint.
+
+`/chemscraper/analyze` predates ChemScraper becoming a normal Kubernetes job and is
+marked deprecated, but it is still mounted and still reachable.
+"""
+import pytest
+
+from services.chemscraper_service import ChemScraperService
+
+
+@pytest.fixture
+def stub_analysis(monkeypatch):
+    """Neutralize the background task.
+
+    TestClient drains background tasks synchronously before returning, so without this
+    the endpoint's response depends on the whole extraction pipeline: it would look for
+    an uploaded PDF and then POST it to the external ChemScraper service. These tests
+    are about what the endpoint accepts, not about that pipeline.
+    """
+    async def _noop(self, *args, **kwargs):
+        return True
+
+    monkeypatch.setattr(ChemScraperService, "runChemscraperOnDocument", _noop)
+
+
+def _analyze(client, **overrides):
+    body = {"jobId": "j1", "user_email": "a@b.edu", "fileList": ["paper.pdf"]}
+    body.update(overrides)
+    return client.post("/chemscraper/analyze", json=body)
+
+
+class TestAnalyzeValidation:
+    def test_empty_file_list_returns_400(self, client):
+        resp = _analyze(client, fileList=[])
+
+        # Was: the function fell out of its `if` with no return statement at all, which
+        # FastAPI renders as HTTP 200 with a null body -- reporting success for a
+        # request that was never accepted, for a job that would never run.
+        assert resp.status_code == 400
+        assert "fileList" in resp.json()["detail"]
+
+    def test_empty_job_id_returns_400(self, client):
+        resp = _analyze(client, jobId="")
+
+        assert resp.status_code == 400
+        assert "jobId" in resp.json()["detail"]
+
+    def test_a_valid_request_is_accepted(self, client, stub_analysis):
+        resp = _analyze(client)
+
+        assert resp.status_code == 202
+        assert resp.json()["jobId"] == "j1"
+
+    def test_an_accepted_request_creates_a_processing_job(self, client, stub_analysis):
+        _analyze(client)
+
+        jobs = client.get("/chemscraper/jobs/j1").json()
+
+        assert len(jobs) == 1
+        assert jobs[0]["phase"] == "processing"

--- a/tests/characterization/test_files_api.py
+++ b/tests/characterization/test_files_api.py
@@ -71,19 +71,29 @@ class TestResults:
         assert resp.status_code == 200
         assert resp.json() is None
 
-    def test_unknown_job_id_returns_200_with_a_serialized_exception(self, client):
+    def test_unknown_job_id_returns_404(self, client):
         resp = client.get(f"/{NOVOSTOIC_OPTSTOIC}/results/never-existed")
 
-        # DEFECT: the service `return`s (rather than `raise`s) an HTTPException, so
-        # FastAPI serializes the exception object as an ordinary response body. The
-        # HTTP status is 200 and the 404 is buried inside the payload, where no
-        # standard client will look for it.
+        # Was: the service `return`ed (rather than `raise`d) an HTTPException, so
+        # FastAPI serialized the exception object as an ordinary response body -- HTTP
+        # 200, with the 404 buried inside the payload where no standard client looks.
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Job not found"
+
+    def test_a_known_job_with_no_output_still_returns_200_null(self, client):
+        """Deliberately unchanged.
+
+        Frontends poll this endpoint while a job runs and treat a null body as "not
+        ready yet". Turning that into a 404 or a 409 is the right answer, but it is a
+        contract change for every existing client, so it belongs with the versioned
+        API rather than in a security fix.
+        """
+        client.post(f"/{NOVOSTOIC_OPTSTOIC}/jobs", json={"job_id": "j1"})
+
+        resp = client.get(f"/{NOVOSTOIC_OPTSTOIC}/results/j1")
+
         assert resp.status_code == 200
-        assert resp.json() == {
-            "detail": "Job not found",
-            "headers": None,
-            "status_code": 404,
-        }
+        assert resp.json() is None
 
     def test_invalid_bucket_returns_400(self, client):
         resp = client.get("/not-a-real-tool/results/j1")

--- a/tests/characterization/test_jobs_api.py
+++ b/tests/characterization/test_jobs_api.py
@@ -11,6 +11,7 @@ import json
 import pytest
 
 from models.enums import JobStatus
+from services import kubejob_service
 
 
 DEFAULTS = "defaults"
@@ -66,35 +67,99 @@ class TestCreateJob:
 class TestCreateJobWithExistingId:
     """The collision branch: POSTing a job_id that already exists.
 
-    Every assertion in this class documents a defect. See PR "legacy fixes".
+    This endpoint is unauthenticated, so naming an existing id proves only that the
+    caller can name it. Each test here previously asserted a defect; see the diff of
+    this file in the "legacy fixes" change for what the behavior used to be.
     """
 
-    def test_returns_200_and_discloses_the_stored_email(self, client):
+    def test_does_not_disclose_the_stored_email(self, client):
         _post_job(client, job_id="victim", email="owner@illinois.edu", job_info='{"secret": 1}')
 
         resp = _post_job(client, job_id="victim")
 
-        # DEFECT: unauthenticated information disclosure. A caller who guesses an
-        # existing job_id is told the owner's email address.
+        # Was: returned the owner's address, making the endpoint an oracle for
+        # harvesting researchers' emails from guessed job_ids.
         assert resp.status_code == 200
-        assert resp.json()["email"] == "owner@illinois.edu"
+        assert resp.json()["email"] is None
 
-    def test_overwrites_the_stored_job_info(self, client):
+    def test_does_not_disclose_the_stored_job_info(self, client):
         _post_job(client, job_id="victim", email="owner@illinois.edu", job_info='{"secret": 1}')
 
-        resp = _post_job(client, job_id="victim", job_info='{"tampered": true}')
+        resp = _post_job(client, job_id="victim")
 
-        # DEFECT: unauthenticated data tampering. The caller's job_info replaces the
-        # owner's stored input, destroying the record of what was actually run.
-        assert resp.json()["job_info"] == '{"tampered": true}'
+        # Was: returned the owner's submitted inputs.
+        assert resp.json()["job_info"] is None
 
-    def test_submits_a_second_kubernetes_job(self, client):
+    def test_still_returns_the_job_id(self, client):
+        """coordinator.py reads job_id from a 200 or a 201, so it must survive."""
+        _post_job(client, job_id="victim")
+
+        resp = _post_job(client, job_id="victim")
+
+        assert resp.status_code == 200
+        assert resp.json()["job_id"] == "victim"
+        assert set(resp.json()) == {"job_id", "run_id", "email", "job_info"}
+
+    def test_does_not_overwrite_the_stored_job_info(self, client):
+        _post_job(client, job_id="victim", email="owner@illinois.edu", job_info='{"secret": 1}')
+
+        _post_job(client, job_id="victim", job_info='{"tampered": true}')
+
+        # Was: the caller's job_info replaced the owner's, destroying the record of
+        # what was actually run.
+        stored = client.get(f"/{DEFAULTS}/jobs/victim").json()[0]["job_info"]
+        assert stored == '{"secret": 1}'
+
+    def test_does_not_submit_a_second_kubernetes_job(self, client):
         _post_job(client, job_id="victim")
         _post_job(client, job_id="victim")
 
-        # DEFECT: create_job runs before the existence check, so a duplicate POST
-        # launches a second pod against the same job_id.
-        assert len(client.k8s_jobs) == 2
+        # Was: create_job ran before the existence check, so a duplicate POST forked a
+        # second run of the same job.
+        assert len(client.k8s_jobs) == 1
+
+    def test_does_not_disturb_the_existing_jobs_phase(self, client):
+        _post_job(client, job_id="victim")
+
+        _post_job(client, job_id="victim")
+
+        assert client.get(f"/{DEFAULTS}/jobs/victim").json()[0]["phase"] == JobStatus.QUEUED
+
+
+class TestKubernetesRejection:
+    """create_job swallows ApiException and reports failure via its return value."""
+
+    def test_a_rejected_submission_returns_400(self, client, monkeypatch):
+        monkeypatch.setattr(
+            kubejob_service,
+            "create_job",
+            lambda **kw: {"status": "error", "message": "jobs.batch already exists"},
+        )
+
+        resp = _post_job(client, job_id="rejected")
+
+        # Was: 201, because the exception never propagated and the return value was
+        # ignored -- the caller was told the job started when no pod existed.
+        assert resp.status_code == 400
+        assert "already exists" in resp.json()["detail"]
+
+    def test_a_rejected_submission_leaves_the_job_in_error_not_queued(self, client, monkeypatch):
+        monkeypatch.setattr(
+            kubejob_service,
+            "create_job",
+            lambda **kw: {"status": "error", "message": "exceeded quota"},
+        )
+
+        _post_job(client, job_id="rejected")
+
+        # Was: stranded at 'queued' forever, with nothing running to advance it.
+        assert client.get(f"/{DEFAULTS}/jobs/rejected").json()[0]["phase"] == JobStatus.ERROR
+
+    def test_a_successful_submission_is_unaffected(self, client):
+        resp = _post_job(client, job_id="fine")
+
+        assert resp.status_code == 201
+        assert client.get(f"/{DEFAULTS}/jobs/fine").json()[0]["phase"] == JobStatus.QUEUED
 
 
 class TestReadJobs:
@@ -135,20 +200,33 @@ class TestReadJobs:
 
 
 class TestDeleteJob:
-    def test_delete_removes_the_row_but_leaves_the_kubernetes_job_running(self, client):
+    def test_delete_removes_the_row_and_the_kubernetes_job(self, client, deleted_k8s_jobs):
         _post_job(client, job_id="j1", run_id="r1")
-        client.k8s_jobs.clear()
 
         resp = client.delete(f"/{DEFAULTS}/jobs/j1/r1")
 
         assert resp.status_code == 200
         assert client.get(f"/{DEFAULTS}/jobs/j1").json() == []
-        # DEFECT: kubejob_service.delete_job() is never called, so the pod keeps
-        # running with no DB row to track it.
-        assert client.k8s_jobs == []
+        # Was: the row was dropped but the pod kept running, consuming cluster
+        # resources with nothing left to observe or stop it.
+        assert deleted_k8s_jobs == [{"job_type": DEFAULTS, "job_id": "j1"}]
 
-    def test_delete_unknown_job_returns_404(self, client):
+    def test_delete_succeeds_even_if_the_cluster_call_fails(self, client, monkeypatch):
+        """A cluster problem must not leave a user unable to delete their own record."""
+        def _boom(**kwargs):
+            raise RuntimeError("cluster unreachable")
+
+        monkeypatch.setattr(kubejob_service, "delete_job", _boom)
+        _post_job(client, job_id="j1", run_id="r1")
+
+        resp = client.delete(f"/{DEFAULTS}/jobs/j1/r1")
+
+        assert resp.status_code == 200
+        assert client.get(f"/{DEFAULTS}/jobs/j1").json() == []
+
+    def test_delete_unknown_job_returns_404(self, client, deleted_k8s_jobs):
         assert client.delete(f"/{DEFAULTS}/jobs/nope/nope").status_code == 404
+        assert deleted_k8s_jobs == []
 
 
 class TestPerToolInputValidation:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,10 @@ from sqlmodel import SQLModel, create_engine  # noqa: E402
 import main  # noqa: E402
 from services.minio_service import MinIOService  # noqa: E402
 
-# db.py builds its engine with echo=True, which makes every test emit the full SQL log.
+# db.py builds its engine with echo=True. SQLAlchemy implements echo by setting the
+# logger's level when the engine is constructed, so this has to run after that import
+# rather than before it, or the engine simply raises the level back to INFO and every
+# test emits a full SQL log.
 logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
 
 
@@ -134,7 +137,19 @@ def created_k8s_jobs(monkeypatch):
 
 
 @pytest.fixture
-def client(fake_minio, created_k8s_jobs):
+def deleted_k8s_jobs(monkeypatch):
+    """Record calls to kubejob_service.delete_job instead of talking to Kubernetes."""
+    calls = []
+
+    def _record(job_type=None, job_id=None):
+        calls.append({"job_type": job_type, "job_id": job_id})
+
+    monkeypatch.setattr(kubejob_service, "delete_job", _record)
+    return calls
+
+
+@pytest.fixture
+def client(fake_minio, created_k8s_jobs, deleted_k8s_jobs):
     main.app.dependency_overrides[MinIOService] = lambda: fake_minio
     with TestClient(main.app) as test_client:
         test_client.minio = fake_minio


### PR DESCRIPTION
> **Stacked on #111**, which is stacked on #109. Review those first; this PR's diff is only the second commit.

Second PR in the FAIR-compliance stack. #111 added the characterization tests; this one changes behavior, and every change flips an assertion those tests were holding.

## The main issue

`POST /{job_type}/jobs` has no authentication, so naming an existing `job_id` proves only that the caller can name it. That path fell through and:

- returned the owning user's **email address** — making the endpoint an oracle for harvesting researchers' addresses from guessed ids
- returned the owner's stored **`job_info`**, disclosing their submitted inputs
- **overwrote** that stored `job_info` with the caller's, destroying the record of what was actually run
- submitted a **second Kubernetes Job** under the same name, forking another run of somebody else's work

It now stops at the existence check and returns 200 with `job_id` and `run_id`, but `email` and `job_info` null.

**Compatibility:** status code and response keys are unchanged. `coordinator.py` reads `job_id` from either a 200 or a 201 when creating EZSpecificity subjobs, and that still resolves — there's a test for it.

## Kubernetes rejections were reported as success

`create_job` catches `ApiException` internally, logs it, and returns a response carrying `status=error` **rather than propagating it**. The `try/except` around the call could therefore only ever catch failures occurring *before* the API request — template rendering, config lookups.

An exceeded quota, an unpullable image, or a name collision returned **201 to the caller while the row sat at `queued` forever** with no pod behind it. `job.py` was the only caller and ignored the return value entirely.

Now checked, using the pattern `reactionminer.py:24` already uses (`if result['status'] == 'error'`), and the job moves to `error`.

This also makes #109's new error handling reachable: that `except` block could not fire for the most likely class of failure.

## DELETE orphaned the pod

`DELETE` dropped only the database row. KubeWatcher looks each event up by `jobId` and discards events whose row is gone, so the work continued, consumed cluster resources, and wrote output to MinIO with nothing able to observe or stop it.

Fixing this required fixing `delete_job` itself: it called `get_job_name_from_id(job_id)` with one argument where the function takes `(job_type, job_id)`, so it raised `TypeError` on **every** invocation. It had no callers, which is why nobody noticed.

The call is best-effort — a cluster problem must not leave a user unable to delete their own record.

## Smaller fixes

- Three services `return`ed an `HTTPException` instead of `raise`-ing it, so FastAPI serialized the exception object as an ordinary response body: HTTP 200, with the 404 buried in the payload. (`novostoic_service.py` ×2, `oed_service.py`)
- `/chemscraper/analyze` fell out of its guard with **no return statement** when `fileList` was empty or `jobId` blank — HTTP 200, null body, reporting success for a request that was never accepted. Now 400.

## Deliberately not changed

Results endpoints still return **200 with a null body** when a known job has not yet written output. Frontends poll these and treat null as "not ready yet". Turning it into a 404 or a 409 is the right answer, but it is a contract change for every existing client, so it belongs with the versioned API rather than with a security fix. `test_a_known_job_with_no_output_still_returns_200_null` records that decision so it isn't mistaken for an oversight.

## On the removed duplicate block

Restructuring `create_job` removed the unreachable duplicate of the row-creation block. That dead code came from #109's conflict merge and is [reported separately there](https://github.com/moleculemaker/mmli-backend/pull/109#issuecomment-5233342172) — if #109 removes it first, this PR will need a trivial rebase.

## Reviewing this

The test diff is the specification. Each previously-`DEFECT:`-marked assertion now asserts the fixed behavior and carries a `Was:` note stating what it used to do, so you can read exactly what changed without reading the implementation.

**52 passing** on the current `pydantic==1.9.2` stack.
